### PR TITLE
Shared CLI package

### DIFF
--- a/lxc-to-lxd/main_migrate.go
+++ b/lxc-to-lxd/main_migrate.go
@@ -12,9 +12,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/lxc/lxd/shared/i18n"
 	"github.com/lxc/lxd/shared/osarch"
 )
@@ -462,7 +462,7 @@ func convertContainer(d lxd.ContainerServer, container *liblxc.Container, storag
 			return err
 		}
 
-		progress := utils.ProgressRenderer{Format: "Transferring container: %s"}
+		progress := cli.ProgressRenderer{Format: "Transferring container: %s"}
 		_, err = op.AddHandler(progress.UpdateOp)
 		if err != nil {
 			progress.Done("")

--- a/lxc/action.go
+++ b/lxc/action.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lxc/lxd/lxc/config"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -169,7 +168,7 @@ func (c *cmdAction) doActionAll(action string, resource remoteResource) error {
 		return err
 	}
 
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Quiet: c.global.flagQuiet,
 	}
 
@@ -179,7 +178,7 @@ func (c *cmdAction) doActionAll(action string, resource remoteResource) error {
 		return err
 	}
 
-	err = utils.CancelableWait(op, &progress)
+	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
 		return err
@@ -258,7 +257,7 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 		return console.Console(d, name)
 	}
 
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Quiet: c.global.flagQuiet,
 	}
 
@@ -269,7 +268,7 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 	}
 
 	// Wait for operation to finish
-	err = utils.CancelableWait(op, &progress)
+	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
 		return fmt.Errorf("%s\n"+i18n.G("Try `lxc info --show-log %s` for more info"), err, nameArg)

--- a/lxc/alias.go
+++ b/lxc/alias.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/lxc/lxd/lxc/utils"
 	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/lxc/lxd/shared/i18n"
 )
@@ -124,14 +123,14 @@ func (c *cmdAliasList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{k, v})
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("ALIAS"),
 		i18n.G("TARGET"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, conf.Aliases)
+	return cli.RenderTable(c.flagFormat, header, data, conf.Aliases)
 }
 
 // Rename.

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -178,7 +177,7 @@ func (c *cmdClusterList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, line)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -191,7 +190,7 @@ func (c *cmdClusterList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("MESSAGE"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, members)
+	return cli.RenderTable(c.flagFormat, header, data, members)
 }
 
 // Show.
@@ -920,7 +919,7 @@ func (c *cmdClusterListTokens) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, line)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -928,7 +927,7 @@ func (c *cmdClusterListTokens) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("EXPIRES AT"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, displayTokens)
+	return cli.RenderTable(c.flagFormat, header, data, displayTokens)
 }
 
 // Revoke Tokens.
@@ -1209,7 +1208,7 @@ func (c *cmdClusterEvacuateAction) Run(cmd *cobra.Command, args []string) error 
 		format = i18n.G("Evacuating cluster member: %s")
 	}
 
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Format: format,
 		Quiet:  c.global.flagQuiet,
 	}

--- a/lxc/cluster_group.go
+++ b/lxc/cluster_group.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -416,7 +415,7 @@ func (c *cmdClusterGroupList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, line)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -424,7 +423,7 @@ func (c *cmdClusterGroupList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("MEMBERS"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, groups)
+	return cli.RenderTable(c.flagFormat, header, data, groups)
 }
 
 // Remove.

--- a/lxc/config_template.go
+++ b/lxc/config_template.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/lxc/lxd/shared/i18n"
@@ -278,13 +277,13 @@ func (c *cmdConfigTemplateList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{template})
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("FILENAME"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, templates)
+	return cli.RenderTable(c.flagFormat, header, data, templates)
 }
 
 // Show.

--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -403,7 +402,7 @@ func (c *cmdConfigTrustList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{cert.Type, cert.Name, tlsCert.Subject.CommonName, fp, issue, expiry})
 	}
 
-	sort.Sort(utils.StringList(data))
+	sort.Sort(cli.StringList(data))
 
 	header := []string{
 		i18n.G("TYPE"),
@@ -414,7 +413,7 @@ func (c *cmdConfigTrustList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("EXPIRY DATE"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, trust)
+	return cli.RenderTable(c.flagFormat, header, data, trust)
 }
 
 // List tokens.
@@ -509,7 +508,7 @@ func (c *cmdConfigTrustListTokens) Run(cmd *cobra.Command, args []string) error 
 		data = append(data, line)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -517,7 +516,7 @@ func (c *cmdConfigTrustListTokens) Run(cmd *cobra.Command, args []string) error 
 		i18n.G("EXPIRES AT"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, displayTokens)
+	return cli.RenderTable(c.flagFormat, header, data, displayTokens)
 }
 
 // Remove.

--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxc/config"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -333,7 +332,7 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 	}
 
 	// Watch the background operation
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Format: i18n.G("Transferring instance: %s"),
 		Quiet:  c.global.flagQuiet,
 	}
@@ -345,7 +344,7 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 	}
 
 	// Wait for the copy to complete
-	err = utils.CancelableWait(op, &progress)
+	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
 		return err
@@ -375,7 +374,7 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 		}
 
 		// Watch the background operation
-		progress := utils.ProgressRenderer{
+		progress := cli.ProgressRenderer{
 			Format: i18n.G("Refreshing instance: %s"),
 			Quiet:  c.global.flagQuiet,
 		}
@@ -387,7 +386,7 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 		}
 
 		// Wait for the copy to complete
-		err = utils.CancelableWait(op, &progress)
+		err = cli.CancelableWait(op, &progress)
 		if err != nil {
 			progress.Done("")
 			return err

--- a/lxc/export.go
+++ b/lxc/export.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -82,7 +81,7 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Watch the background operation
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Format: i18n.G("Backing up instance: %s"),
 		Quiet:  c.global.flagQuiet,
 	}
@@ -94,7 +93,7 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Wait until backup is done
-	err = utils.CancelableWait(op, &progress)
+	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
 		return err
@@ -140,7 +139,7 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Prepare the download request
-	progress = utils.ProgressRenderer{
+	progress = cli.ProgressRenderer{
 		Format: i18n.G("Exporting the backup: %s"),
 		Quiet:  c.global.flagQuiet,
 	}

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -19,7 +19,6 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/lxc/lxd/shared/i18n"
@@ -405,7 +404,7 @@ func (c *cmdFilePull) Run(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		progress := utils.ProgressRenderer{
+		progress := cli.ProgressRenderer{
 			Format: fmt.Sprintf(i18n.G("Pulling %s from %s: %%s"), targetPath, pathSpec[1]),
 			Quiet:  c.global.flagQuiet,
 		}
@@ -679,7 +678,7 @@ func (c *cmdFilePush) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		progress := utils.ProgressRenderer{
+		progress := cli.ProgressRenderer{
 			Format: fmt.Sprintf(i18n.G("Pushing %s to %s: %%s"), f.Name(), fpath),
 			Quiet:  c.global.flagQuiet,
 		}
@@ -745,7 +744,7 @@ func (c *cmdFile) recursivePullFile(d lxd.InstanceServer, inst string, p string,
 			return err
 		}
 
-		progress := utils.ProgressRenderer{
+		progress := cli.ProgressRenderer{
 			Format: fmt.Sprintf(i18n.G("Pulling %s from %s: %%s"), p, target),
 			Quiet:  c.global.flagQuiet,
 		}
@@ -845,7 +844,7 @@ func (c *cmdFile) recursivePushFile(d lxd.InstanceServer, inst string, source st
 			readCloser = f
 		}
 
-		progress := utils.ProgressRenderer{
+		progress := cli.ProgressRenderer{
 			Format: fmt.Sprintf(i18n.G("Pushing %s to %s: %%s"), p, targetPath),
 			Quiet:  c.global.flagQuiet,
 		}

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -14,7 +14,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -260,7 +259,7 @@ func (c *cmdImageCopy) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Register progress handler
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Format: i18n.G("Copying the image: %s"),
 		Quiet:  c.global.flagQuiet,
 	}
@@ -272,7 +271,7 @@ func (c *cmdImageCopy) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Wait for operation to finish
-	err = utils.CancelableWait(op, &progress)
+	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
 		return err
@@ -555,7 +554,7 @@ func (c *cmdImageExport) Run(cmd *cobra.Command, args []string) error {
 	defer func() { _ = destRootfs.Close() }()
 
 	// Prepare the download request
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Format: i18n.G("Exporting the image: %s"),
 		Quiet:  c.global.flagQuiet,
 	}
@@ -764,7 +763,7 @@ func (c *cmdImageImport) Run(cmd *cobra.Command, args []string) error {
 		image.Properties[strings.TrimSpace(fields[0])] = strings.TrimSpace(fields[1])
 	}
 
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Format: i18n.G("Transferring image: %s"),
 		Quiet:  c.global.flagQuiet,
 	}
@@ -842,7 +841,7 @@ func (c *cmdImageImport) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Wait for operation to finish
-	err = utils.CancelableWait(op, &progress)
+	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
 		return err
@@ -1311,7 +1310,7 @@ func (c *cmdImageList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, row)
 	}
 
-	sort.Sort(utils.StringList(data))
+	sort.Sort(cli.StringList(data))
 
 	rawData := make([]*api.Image, len(images))
 	for i := range images {
@@ -1323,7 +1322,7 @@ func (c *cmdImageList) Run(cmd *cobra.Command, args []string) error {
 		headers = append(headers, column.Name)
 	}
 
-	return utils.RenderTable(c.flagFormat, headers, data, rawData)
+	return cli.RenderTable(c.flagFormat, headers, data, rawData)
 }
 
 // Refresh.
@@ -1363,7 +1362,7 @@ func (c *cmdImageRefresh) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		image := c.image.dereferenceAlias(resource.server, "", resource.name)
-		progress := utils.ProgressRenderer{
+		progress := cli.ProgressRenderer{
 			Format: i18n.G("Refreshing the image: %s"),
 			Quiet:  c.global.flagQuiet,
 		}

--- a/lxc/image_alias.go
+++ b/lxc/image_alias.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/lxc/lxd/shared/i18n"
@@ -229,7 +228,7 @@ func (c *cmdImageAliasList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{alias.Name, alias.Target[0:12], strings.ToUpper(alias.Type), alias.Description})
 	}
 
-	sort.Sort(utils.StringList(data))
+	sort.Sort(cli.StringList(data))
 
 	header := []string{
 		i18n.G("ALIAS"),
@@ -238,7 +237,7 @@ func (c *cmdImageAliasList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("DESCRIPTION"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, aliases)
+	return cli.RenderTable(c.flagFormat, header, data, aliases)
 }
 
 // Rename.

--- a/lxc/import.go
+++ b/lxc/import.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/lxc/lxd/shared/i18n"
@@ -91,7 +90,7 @@ func (c *cmdImport) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Format: i18n.G("Importing instance: %s"),
 		Quiet:  c.global.flagQuiet,
 	}
@@ -116,7 +115,7 @@ func (c *cmdImport) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Wait for operation to finish.
-	err = utils.CancelableWait(op, &progress)
+	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
 		return err

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxc/config"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -632,7 +631,7 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, remote config.Remote, name 
 			i18n.G("Stateful"),
 		}
 
-		_ = utils.RenderTable(utils.TableFormatTable, snapHeader, snapData, inst.Snapshots)
+		_ = cli.RenderTable(cli.TableFormatTable, snapHeader, snapData, inst.Snapshots)
 	}
 
 	// List backups
@@ -684,7 +683,7 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, remote config.Remote, name 
 			i18n.G("Optimized Storage"),
 		}
 
-		_ = utils.RenderTable(utils.TableFormatTable, backupHeader, backupData, inst.Backups)
+		_ = cli.RenderTable(cli.TableFormatTable, backupHeader, backupData, inst.Backups)
 	}
 
 	if showLog {

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxc/config"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/lxc/lxd/shared/i18n"
@@ -356,7 +355,7 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 		}
 
 		// Watch the background operation
-		progress := utils.ProgressRenderer{
+		progress := cli.ProgressRenderer{
 			Format: i18n.G("Retrieving image: %s"),
 			Quiet:  c.global.flagQuiet,
 		}
@@ -367,7 +366,7 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 			return nil, "", err
 		}
 
-		err = utils.CancelableWait(op, &progress)
+		err = cli.CancelableWait(op, &progress)
 		if err != nil {
 			progress.Done("")
 			return nil, "", err

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/lxc/lxd/shared/i18n"
@@ -89,7 +88,7 @@ func (c *cmdLaunch) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Quiet: c.global.flagQuiet,
 	}
 
@@ -100,7 +99,7 @@ func (c *cmdLaunch) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Wait for operation to finish
-	err = utils.CancelableWait(op, &progress)
+	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
 		prettyName := name

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxc/config"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -437,14 +436,14 @@ func (c *cmdList) showInstances(instances []api.InstanceFull, filters []string, 
 		data = append(data, col)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	headers := []string{}
 	for _, column := range columns {
 		headers = append(headers, column.Name)
 	}
 
-	return utils.RenderTable(c.flagFormat, headers, data, instancesFiltered)
+	return cli.RenderTable(c.flagFormat, headers, data, instancesFiltered)
 }
 
 func (c *cmdList) Run(cmd *cobra.Command, args []string) error {

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lxc/lxd/lxc/config"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -304,7 +303,7 @@ func moveClusterInstance(conf *config.Config, sourceResource string, destResourc
 	}
 
 	// Watch the background operation
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Format: i18n.G("Transferring instance: %s"),
 		Quiet:  quiet,
 	}
@@ -315,7 +314,7 @@ func moveClusterInstance(conf *config.Config, sourceResource string, destResourc
 		return err
 	}
 	// Wait for the move to complete
-	err = utils.CancelableWait(op, &progress)
+	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
 		return err

--- a/lxc/network.go
+++ b/lxc/network.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -958,7 +957,7 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -971,7 +970,7 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("STATE"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, networks)
+	return cli.RenderTable(c.flagFormat, header, data, networks)
 }
 
 // List leases.
@@ -1030,7 +1029,7 @@ func (c *cmdNetworkListLeases) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, entry)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("HOSTNAME"),
@@ -1043,7 +1042,7 @@ func (c *cmdNetworkListLeases) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, i18n.G("LOCATION"))
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, leases)
+	return cli.RenderTable(c.flagFormat, header, data, leases)
 }
 
 // Rename.

--- a/lxc/network_acl.go
+++ b/lxc/network_acl.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -142,7 +141,7 @@ func (c *cmdNetworkACLList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -150,7 +149,7 @@ func (c *cmdNetworkACLList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("USED BY"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, acls)
+	return cli.RenderTable(c.flagFormat, header, data, acls)
 }
 
 // Show.

--- a/lxc/network_forward.go
+++ b/lxc/network_forward.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -139,7 +138,7 @@ func (c *cmdNetworkForwardList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("LISTEN ADDRESS"),
@@ -152,7 +151,7 @@ func (c *cmdNetworkForwardList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, i18n.G("LOCATION"))
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, forwards)
+	return cli.RenderTable(c.flagFormat, header, data, forwards)
 }
 
 // Show.

--- a/lxc/network_load_balancer.go
+++ b/lxc/network_load_balancer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -142,7 +141,7 @@ func (c *cmdNetworkLoadBalancerList) Run(cmd *cobra.Command, args []string) erro
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("LISTEN ADDRESS"),
@@ -154,7 +153,7 @@ func (c *cmdNetworkLoadBalancerList) Run(cmd *cobra.Command, args []string) erro
 		header = append(header, i18n.G("LOCATION"))
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, loadBalancers)
+	return cli.RenderTable(c.flagFormat, header, data, loadBalancers)
 }
 
 // Show.

--- a/lxc/network_peer.go
+++ b/lxc/network_peer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -134,7 +133,7 @@ func (c *cmdNetworkPeerList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -143,7 +142,7 @@ func (c *cmdNetworkPeerList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("STATE"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, peers)
+	return cli.RenderTable(c.flagFormat, header, data, peers)
 }
 
 // Show.

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -133,7 +132,7 @@ func (c *cmdNetworkZoneList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -141,7 +140,7 @@ func (c *cmdNetworkZoneList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("USED BY"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, zones)
+	return cli.RenderTable(c.flagFormat, header, data, zones)
 }
 
 // Show.
@@ -697,7 +696,7 @@ func (c *cmdNetworkZoneRecordList) Run(cmd *cobra.Command, args []string) error 
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -705,7 +704,7 @@ func (c *cmdNetworkZoneRecordList) Run(cmd *cobra.Command, args []string) error 
 		i18n.G("ENTRIES"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, records)
+	return cli.RenderTable(c.flagFormat, header, data, records)
 }
 
 // Show.

--- a/lxc/operation.go
+++ b/lxc/operation.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/lxc/lxd/shared/i18n"
 )
@@ -156,7 +155,7 @@ func (c *cmdOperationList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, entry)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("ID"),
@@ -169,7 +168,7 @@ func (c *cmdOperationList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, i18n.G("LOCATION"))
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, operations)
+	return cli.RenderTable(c.flagFormat, header, data, operations)
 }
 
 // Show.

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -627,14 +626,14 @@ func (c *cmdProfileList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{profile.Name, profile.Description, strUsedBy})
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
 		i18n.G("DESCRIPTION"),
 		i18n.G("USED BY")}
 
-	return utils.RenderTable(c.flagFormat, header, data, profiles)
+	return cli.RenderTable(c.flagFormat, header, data, profiles)
 }
 
 // Remove.

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -480,7 +479,7 @@ func (c *cmdProjectList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{name, images, profiles, storageVolumes, storageBuckets, networks, networkZones, project.Description, strUsedBy})
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -494,7 +493,7 @@ func (c *cmdProjectList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("USED BY"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, projects)
+	return cli.RenderTable(c.flagFormat, header, data, projects)
 }
 
 // Rename.
@@ -821,7 +820,7 @@ func (c *cmdProjectInfo) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{strings.ToUpper(k), limit, usage})
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("RESOURCE"),
@@ -829,5 +828,5 @@ func (c *cmdProjectInfo) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("USAGE"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, projectState)
+	return cli.RenderTable(c.flagFormat, header, data, projectState)
 }

--- a/lxc/publish.go
+++ b/lxc/publish.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -249,7 +248,7 @@ func (c *cmdPublish) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Watch the background operation
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Format: i18n.G("Publishing instance: %s"),
 		Quiet:  c.global.flagQuiet,
 	}
@@ -261,7 +260,7 @@ func (c *cmdPublish) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Wait for the copy to complete
-	err = utils.CancelableWait(op, &progress)
+	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
 		return err

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxc/config"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -724,7 +723,7 @@ func (c *cmdRemoteList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{strName, rc.Addr, rc.Protocol, rc.AuthType, strPublic, strStatic, strGlobal})
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -736,7 +735,7 @@ func (c *cmdRemoteList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("GLOBAL"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, conf.Remotes)
+	return cli.RenderTable(c.flagFormat, header, data, conf.Remotes)
 }
 
 // Rename.

--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -621,7 +620,7 @@ func (c *cmdStorageList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -636,7 +635,7 @@ func (c *cmdStorageList) Run(cmd *cobra.Command, args []string) error {
 	header = append(header, i18n.G("USED BY"))
 	header = append(header, i18n.G("STATE"))
 
-	return utils.RenderTable(c.flagFormat, header, data, pools)
+	return cli.RenderTable(c.flagFormat, header, data, pools)
 }
 
 // Set.

--- a/lxc/storage_bucket.go
+++ b/lxc/storage_bucket.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -489,7 +488,7 @@ func (c *cmdStorageBucketList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -500,7 +499,7 @@ func (c *cmdStorageBucketList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, i18n.G("LOCATION"))
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, buckets)
+	return cli.RenderTable(c.flagFormat, header, data, buckets)
 }
 
 // Set.
@@ -784,7 +783,7 @@ func (c *cmdStorageBucketKeyList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.SortColumnsNaturally(data))
+	sort.Sort(cli.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -792,7 +791,7 @@ func (c *cmdStorageBucketKeyList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("ROLE"),
 	}
 
-	return utils.RenderTable(c.flagFormat, header, data, bucketKeys)
+	return cli.RenderTable(c.flagFormat, header, data, bucketKeys)
 }
 
 // Create Key.

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -13,7 +13,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	lxd "github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -479,7 +478,7 @@ func (c *cmdStorageVolumeCopy) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Register progress handler
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Format: opMsg,
 		Quiet:  c.global.flagQuiet,
 	}
@@ -491,7 +490,7 @@ func (c *cmdStorageVolumeCopy) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Wait for operation to finish
-	err = utils.CancelableWait(op, &progress)
+	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
 		return err
@@ -1272,14 +1271,14 @@ func (c *cmdStorageVolumeInfo) Run(cmd *cobra.Command, args []string) error {
 			snapData = append(snapData, row)
 		}
 
-		sort.Sort(utils.SortColumnsNaturally(snapData))
+		sort.Sort(cli.SortColumnsNaturally(snapData))
 		snapHeader := []string{
 			i18n.G("Name"),
 			i18n.G("Description"),
 			i18n.G("Expires at"),
 		}
 
-		_ = utils.RenderTable(utils.TableFormatTable, snapHeader, snapData, volSnapshots)
+		_ = cli.RenderTable(cli.TableFormatTable, snapHeader, snapData, volSnapshots)
 	}
 
 	// List backups
@@ -1331,7 +1330,7 @@ func (c *cmdStorageVolumeInfo) Run(cmd *cobra.Command, args []string) error {
 			i18n.G("Optimized Storage"),
 		}
 
-		_ = utils.RenderTable(utils.TableFormatTable, backupHeader, backupData, volBackups)
+		_ = cli.RenderTable(cli.TableFormatTable, backupHeader, backupData, volBackups)
 	}
 
 	return nil
@@ -1444,7 +1443,7 @@ func (c *cmdStorageVolumeList) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(columns) >= 2 {
-		sort.Sort(utils.ByNameAndType(data))
+		sort.Sort(cli.ByNameAndType(data))
 	}
 
 	rawData := make([]*api.StorageVolume, len(volumes))
@@ -1457,7 +1456,7 @@ func (c *cmdStorageVolumeList) Run(cmd *cobra.Command, args []string) error {
 		headers = append(headers, column.Name)
 	}
 
-	return utils.RenderTable(c.flagFormat, headers, data, rawData)
+	return cli.RenderTable(c.flagFormat, headers, data, rawData)
 }
 
 func (c *cmdStorageVolumeList) parseColumns(clustered bool) ([]volumeColumn, error) {
@@ -2155,7 +2154,7 @@ func (c *cmdStorageVolumeExport) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Watch the background operation
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Format: i18n.G("Backing up storage volume: %s"),
 		Quiet:  c.global.flagQuiet,
 	}
@@ -2167,7 +2166,7 @@ func (c *cmdStorageVolumeExport) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Wait until backup is done
-	err = utils.CancelableWait(op, &progress)
+	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
 		return err
@@ -2207,7 +2206,7 @@ func (c *cmdStorageVolumeExport) Run(cmd *cobra.Command, args []string) error {
 	defer func() { _ = target.Close() }()
 
 	// Prepare the download request
-	progress = utils.ProgressRenderer{
+	progress = cli.ProgressRenderer{
 		Format: i18n.G("Exporting the backup: %s"),
 		Quiet:  c.global.flagQuiet,
 	}
@@ -2293,7 +2292,7 @@ func (c *cmdStorageVolumeImport) Run(cmd *cobra.Command, args []string) error {
 		volName = args[2]
 	}
 
-	progress := utils.ProgressRenderer{
+	progress := cli.ProgressRenderer{
 		Format: i18n.G("Importing custom volume: %s"),
 		Quiet:  c.global.flagQuiet,
 	}
@@ -2317,7 +2316,7 @@ func (c *cmdStorageVolumeImport) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Wait for operation to finish.
-	err = utils.CancelableWait(op, &progress)
+	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
 		return err

--- a/lxc/utils_test.go
+++ b/lxc/utils_test.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared/api"
 )
 
@@ -17,27 +15,6 @@ type utilsTestSuite struct {
 
 func TestUtilsTestSuite(t *testing.T) {
 	suite.Run(t, new(utilsTestSuite))
-}
-
-// stringList can be used to sort a list of strings.
-func (s *utilsTestSuite) Test_stringList() {
-	data := [][]string{{"foo", "bar"}, {"baz", "bza"}}
-	sort.Sort(utils.StringList(data))
-	s.Equal([][]string{{"baz", "bza"}, {"foo", "bar"}}, data)
-}
-
-// The first different string is used in sorting.
-func (s *utilsTestSuite) Test_stringList_sort_by_column() {
-	data := [][]string{{"foo", "baz"}, {"foo", "bar"}}
-	sort.Sort(utils.StringList(data))
-	s.Equal([][]string{{"foo", "bar"}, {"foo", "baz"}}, data)
-}
-
-// Empty strings are sorted last.
-func (s *utilsTestSuite) Test_stringList_empty_strings() {
-	data := [][]string{{"", "bar"}, {"foo", "baz"}}
-	sort.Sort(utils.StringList(data))
-	s.Equal([][]string{{"foo", "baz"}, {"", "bar"}}, data)
 }
 
 func (s *utilsTestSuite) TestIsAliasesSubsetTrue() {

--- a/lxc/warning.go
+++ b/lxc/warning.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/lxc/lxd/shared/i18n"
@@ -154,7 +153,7 @@ func (c *cmdWarningList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, row)
 	}
 
-	sort.Sort(utils.StringList(data))
+	sort.Sort(cli.StringList(data))
 
 	rawData := make([]*api.Warning, len(warnings))
 	for i := range warnings {
@@ -166,7 +165,7 @@ func (c *cmdWarningList) Run(cmd *cobra.Command, args []string) error {
 		headers = append(headers, column.Name)
 	}
 
-	return utils.RenderTable(c.flagFormat, headers, data, rawData)
+	return cli.RenderTable(c.flagFormat, headers, data, rawData)
 }
 
 func (c *cmdWarningList) countColumnData(warning api.Warning) string {

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -18,7 +18,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -572,7 +571,7 @@ func (c *cmdMigrate) Run(cmd *cobra.Command, args []string) error {
 		_, _ = server.DeleteInstance(config.InstanceArgs.Name)
 	})
 
-	progress := utils.ProgressRenderer{Format: "Transferring instance: %s"}
+	progress := cli.ProgressRenderer{Format: "Transferring instance: %s"}
 	_, err = op.AddHandler(progress.UpdateOp)
 	if err != nil {
 		progress.Done("")

--- a/lxd/main_cluster.go
+++ b/lxd/main_cluster.go
@@ -15,13 +15,13 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
+	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/lxc/lxd/shared/termios"
 )
 
@@ -363,7 +363,7 @@ func (c *cmdClusterListDatabase) Run(cmd *cobra.Command, args []string) error {
 		data[i] = []string{address}
 	}
 
-	_ = utils.RenderTable(utils.TableFormatTable, columns, data, nil)
+	_ = cli.RenderTable(cli.TableFormatTable, columns, data, nil)
 
 	return nil
 }

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -44,7 +44,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -115,7 +115,7 @@ msgstr ""
 "### Zum Beispiel:\n"
 "###  description: Mein eigenes Abbild\n"
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -163,7 +163,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -222,7 +222,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -268,7 +268,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -310,7 +310,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -352,7 +352,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -387,7 +387,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -413,7 +413,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -439,7 +439,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -477,7 +477,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -516,7 +516,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -555,7 +555,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -563,71 +563,66 @@ msgstr ""
 "### Dies ist eine yaml-Repräsentation des Cluster-Mitglieds.\n"
 "### Jede mit '# beginnende Zeile wird ignoriert."
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (ID: %d, Online: %v, NUMA-Knoten: %v)"
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, fuzzy, c-format
 msgid "%s (%d available)"
 msgstr "%s (%d mehr)"
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr "%v (zwei weitere Male unterbrechen, um zu erzwingen)"
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr "(kein Wert)"
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Level %d (Typ: %s): %s"
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partition %d"
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 #, fuzzy
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 #, fuzzy
 msgid "--console can't be used with --all"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -636,11 +631,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -650,44 +645,44 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--project cannot be used with the query command"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 #, fuzzy
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 #, fuzzy
 msgid "<alias>"
 msgstr "Aliasse:\n"
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 #, fuzzy
 msgid "<alias> <target>"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -696,7 +691,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -705,31 +700,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, fuzzy, c-format
 msgid "Access key: %s"
 msgstr "Profil %s erstellt\n"
@@ -739,7 +734,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Access the expanded configuration"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -754,20 +749,20 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr "Aktion (Standard: GET)"
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -776,16 +771,16 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 #, fuzzy
 msgid "Add new aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -797,11 +792,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -818,15 +813,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -836,80 +831,80 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Add roles to a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, fuzzy, c-format
 msgid "Address: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, fuzzy, c-format
 msgid "Alias %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, fuzzy, c-format
 msgid "Alias %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr "Aliasname fehlt"
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, fuzzy, c-format
 msgid "Aliases already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 #, fuzzy
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 #, fuzzy
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, fuzzy, c-format
 msgid "Architecture: %v"
 msgstr "Architektur: %s\n"
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -918,40 +913,40 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 #, fuzzy
 msgid "Attach network interfaces to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 #, fuzzy
 msgid "Attach new network interfaces to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -968,50 +963,50 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 #, fuzzy
 msgid "Available projects:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -1020,103 +1015,103 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, fuzzy, c-format
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, fuzzy, c-format
 msgid "Brand: %v"
 msgstr "Erstellt: %s"
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr " Prozessorauslastung:"
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 #, fuzzy
 msgid "CREATED"
 msgstr "ERSTELLT AM"
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr "ERSTELLT AM"
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1125,7 +1120,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 #, fuzzy
 msgid "Caches:"
 msgstr ""
@@ -1134,15 +1129,15 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1151,15 +1146,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1167,11 +1162,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1180,40 +1175,40 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1222,32 +1217,32 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1257,85 +1252,85 @@ msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, fuzzy, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr "Spalten"
 
@@ -1351,37 +1346,37 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
@@ -1390,33 +1385,33 @@ msgstr "YAML Analyse Fehler %v\n"
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr "Kopiere Aliasse von der Quelle"
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1424,12 +1419,12 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 #, fuzzy
 msgid "Copy instances within or in between LXD servers"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1449,121 +1444,121 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 #, fuzzy
 msgid "Copy the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, fuzzy, c-format
 msgid "Core %d"
 msgstr "Fehler: %v\n"
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 #, fuzzy
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
-msgstr ""
-
-#: lxc/init.go:59
-#, fuzzy
-msgid "Create a virtual machine"
-msgstr "kann nicht zum selben Container Namen kopieren"
-
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
-msgid "Create aliases for existing images"
 msgstr ""
 
 #: lxc/init.go:58
 #, fuzzy
+msgid "Create a virtual machine"
+msgstr "kann nicht zum selben Container Namen kopieren"
+
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
+msgid "Create aliases for existing images"
+msgstr ""
+
+#: lxc/init.go:57
+#, fuzzy
 msgid "Create an empty instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 #, fuzzy
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1580,165 +1575,165 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 #, fuzzy
 msgid "Create instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 #, fuzzy
 msgid "Create new instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 #, fuzzy
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 #, fuzzy
 msgid "Create projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr "Erstelle %s"
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 #, fuzzy
 msgid "Creating the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 #, fuzzy
 msgid "Delete instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1748,79 +1743,79 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Delete instances and snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 #, fuzzy
 msgid "Delete projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1828,115 +1823,115 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1982,7 +1977,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1991,13 +1986,13 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "Falsche Anzahl an Objekten im Abbild, Container oder Sicherungspunkt gelesen."
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2005,7 +2000,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2017,32 +2012,32 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 #, fuzzy
 msgid "Disk:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 #, fuzzy
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2050,57 +2045,57 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "ABLAUFDATUM"
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 #, fuzzy
 msgid "Edit instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2115,81 +2110,81 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 #, fuzzy
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2204,7 +2199,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -2212,22 +2207,22 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Flüchtiger Container"
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, fuzzy, c-format
 msgid "Error updating template file: %s"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2236,7 +2231,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2268,84 +2263,84 @@ msgstr ""
 "\n"
 "lxc exec <Container> [--env EDITOR=/usr/bin/vim]... <Befehl>\n"
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 #, fuzzy
 msgid "Export instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2360,37 +2355,37 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2400,31 +2395,31 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2434,27 +2429,27 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 #, fuzzy
 msgid "Failed to get the new instance name"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2464,38 +2459,38 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr ""
 "Anzeigen von Informationen über entfernte Instanzen wird noch nicht "
 "unterstützt\n"
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, fuzzy, c-format
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2503,11 +2498,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2520,7 +2515,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2544,16 +2539,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2565,7 +2560,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2574,30 +2569,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2605,24 +2600,24 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -2637,63 +2632,63 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for instance or server configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 #, fuzzy
 msgid "Get values for network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2702,88 +2697,88 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 #, fuzzy
 msgid "Host interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 #, fuzzy
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2797,98 +2792,98 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, fuzzy, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 #, fuzzy
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 #, fuzzy
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2896,43 +2891,43 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2942,25 +2937,20 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 #, fuzzy
 msgid "Invalid certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
-
-#: lxc/utils/table.go:65
-#, fuzzy, c-format
-msgid "Invalid format %q"
-msgstr "Ungültiges Ziel %s"
 
 #: lxc/monitor.go:71
 #, fuzzy, c-format
@@ -2972,7 +2962,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -2982,32 +2972,32 @@ msgstr "Ungültige Quelle %s"
 msgid "Invalid key=value configuration: %s"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,34 +3006,34 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3052,29 +3042,29 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -3086,130 +3076,130 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Architektur: %s\n"
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 #, fuzzy
 msgid "List aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 #, fuzzy
 msgid "List all warnings"
 msgstr "Aliasse:\n"
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -3241,17 +3231,17 @@ msgstr ""
 msgid "List instance devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 #, fuzzy
 msgid "List instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, fuzzy
 msgid "List instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, fuzzy, c-format
 msgid ""
 "List instances\n"
@@ -3348,34 +3338,34 @@ msgstr ""
 "* \"security.privileged=1\" listet alle privilegierten Container\n"
 "* \"s.privileged=1\" ebenfalls\n"
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3394,20 +3384,20 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 #, fuzzy
 msgid "List warnings"
 msgstr "Aliasse:\n"
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -3430,11 +3420,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3443,35 +3433,35 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 #, fuzzy
 msgid "Lower device"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 #, fuzzy
 msgid "Lower devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 #, fuzzy
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3480,63 +3470,63 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 #, fuzzy
 msgid "Make the image public"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3545,7 +3535,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 #, fuzzy
 msgid "Manage command aliases"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -3555,22 +3545,22 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Manage devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 #, fuzzy
 msgid "Manage image aliases"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 #, fuzzy
 msgid "Manage images"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3594,7 +3584,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 #, fuzzy
 msgid "Manage instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3604,127 +3594,127 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Manage instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 #, fuzzy
 msgid "Manage profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 #, fuzzy
 msgid "Manage projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 #, fuzzy
 msgid "Manage storage pools and volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Fehlerhafte Profil URL %s"
@@ -3739,43 +3729,43 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Member %q does not have role %q"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3785,57 +3775,57 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 #, fuzzy
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 #, fuzzy
 msgid "Missing key name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 #, fuzzy
 msgid "Missing listen address"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3847,116 +3837,116 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 #, fuzzy
 msgid "Missing target network"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3972,27 +3962,27 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 #, fuzzy
 msgid "Move instances within or in between LXD servers"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4008,271 +3998,271 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 #, fuzzy
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, fuzzy, c-format
 msgid "Network %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, fuzzy, c-format
 msgid "Network %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 #, fuzzy
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 #, fuzzy
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4281,54 +4271,54 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "kein Wert in %q gefunden\n"
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, fuzzy, c-format
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4340,57 +4330,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4399,55 +4389,55 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 #, fuzzy
 msgid "Pause instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4467,7 +4457,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, fuzzy, c-format
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
@@ -4477,134 +4467,134 @@ msgstr "Profil %s erstellt\n"
 msgid "Processing aliases failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, fuzzy, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, fuzzy, c-format
 msgid "Profile %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, fuzzy, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, fuzzy, c-format
 msgid "Profile %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, fuzzy, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 #, fuzzy
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, fuzzy, c-format
 msgid "Public: %s"
 msgstr "Öffentlich: %s\n"
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 #, fuzzy
 msgid "Publish instances as images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,90 +4603,85 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-#, fuzzy
-msgid "Remote operation canceled by user"
-msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4706,44 +4691,44 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 #, fuzzy
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4753,26 +4738,26 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove instance devices"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4781,25 +4766,25 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4808,49 +4793,49 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 #, fuzzy
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 #, fuzzy
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4858,23 +4843,23 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 #, fuzzy
 msgid "Restart instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4891,17 +4876,17 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4910,93 +4895,93 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Erstellt: %s"
@@ -5005,21 +4990,21 @@ msgstr "Erstellt: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Der Server vertraut uns nicht nachdem er unser Zertifikat hinzugefügt hat"
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5028,12 +5013,12 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5060,7 +5045,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -5078,12 +5063,12 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5092,11 +5077,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5105,12 +5090,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5119,12 +5104,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5133,12 +5118,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5147,12 +5132,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5161,16 +5146,16 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5179,12 +5164,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5193,12 +5178,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5207,12 +5192,12 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5221,12 +5206,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5235,23 +5220,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5263,21 +5248,21 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 #, fuzzy
 msgid "Show content of instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -5290,7 +5275,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Geräte zu Containern oder Profilen hinzufügen"
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -5304,7 +5289,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Show instance or server configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 #, fuzzy
 msgid "Show instance or server information"
 msgstr "Profil %s erstellt\n"
@@ -5317,83 +5302,83 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 #, fuzzy
 msgid "Show network ACL configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5401,121 +5386,121 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 #, fuzzy
 msgid "Show the instance's last 100 log lines?"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, fuzzy, c-format
 msgid "Size: %.2fMB"
 msgstr "Größe: %.2vMB\n"
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 #, fuzzy
 msgid "Start instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 #, fuzzy
 msgid "State"
 msgstr "Erstellt: %s"
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 #, fuzzy
 msgid "Stop instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 #, fuzzy
 msgid "Stopping instance failed!"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5525,143 +5510,143 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Stopping the instance failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, fuzzy, c-format
 msgid "Storage bucket key %s added"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, fuzzy, c-format
 msgid "Storage bucket key %s removed"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, fuzzy, c-format
 msgid "Storage pool %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, fuzzy, c-format
 msgid "Storage pool %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, fuzzy, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 #, fuzzy
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 #, fuzzy
 msgid "The --mode flag can't be used with --storage"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 #, fuzzy
 msgid "The --mode flag can't be used with --target-project"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -5670,17 +5655,17 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 #, fuzzy
 msgid "The --storage flag can't be used with --target"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5689,7 +5674,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5697,17 +5682,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5727,34 +5712,34 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 #, fuzzy
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5770,25 +5755,25 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 #, fuzzy
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Wartezeit bevor der Container gestoppt wird."
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 #, fuzzy
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5803,69 +5788,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, fuzzy, c-format
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Akzeptiere Zertifikat"
@@ -5876,70 +5861,70 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, fuzzy, c-format
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5949,12 +5934,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, fuzzy, c-format
 msgid "Unknown key: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -5964,12 +5949,12 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -5979,7 +5964,7 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5988,114 +5973,114 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 #, fuzzy
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6104,7 +6089,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6113,43 +6098,43 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "Fehler: %v\n"
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6158,11 +6143,11 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6171,7 +6156,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 #, fuzzy
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
@@ -6190,9 +6175,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6205,17 +6190,17 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 #, fuzzy
 msgid "You must specify a destination instance name when using --target"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -6223,7 +6208,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -6231,11 +6216,11 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -6243,7 +6228,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 #, fuzzy
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
@@ -6251,7 +6236,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -6259,7 +6244,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -6268,7 +6253,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 #, fuzzy
 msgid "[<remote>:] [<cert>]"
 msgstr ""
@@ -6277,7 +6262,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -6285,7 +6270,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
@@ -6294,8 +6279,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -6303,7 +6288,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -6311,7 +6296,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -6319,7 +6304,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -6327,7 +6312,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -6335,7 +6320,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -6352,7 +6337,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -6360,7 +6345,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -6368,7 +6353,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -6376,7 +6361,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -6384,7 +6369,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -6393,7 +6378,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
@@ -6402,7 +6387,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -6410,7 +6395,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -6419,7 +6404,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
@@ -6428,8 +6413,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6437,7 +6422,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -6445,7 +6430,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -6454,7 +6439,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -6463,7 +6448,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -6471,7 +6456,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -6479,7 +6464,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
@@ -6487,7 +6472,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -6495,7 +6480,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -6504,7 +6489,7 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6553,7 +6538,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -6562,7 +6547,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -6580,8 +6565,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 #, fuzzy
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
@@ -6599,7 +6584,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
@@ -6616,7 +6601,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 #, fuzzy
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
@@ -6624,7 +6609,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -6633,7 +6618,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -6641,7 +6626,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -6651,7 +6636,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -6669,7 +6654,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
@@ -6678,7 +6663,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -6697,8 +6682,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -6707,7 +6692,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -6716,7 +6701,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -6725,7 +6710,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -6733,7 +6718,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -6750,9 +6735,9 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6760,7 +6745,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -6768,7 +6753,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
@@ -6776,7 +6761,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -6784,7 +6769,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -6792,9 +6777,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6802,7 +6787,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -6810,7 +6795,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -6820,8 +6805,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -6829,7 +6814,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -6837,7 +6822,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -6847,13 +6832,13 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -6861,7 +6846,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
@@ -6869,7 +6854,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -6877,7 +6862,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
@@ -6885,7 +6870,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -6893,7 +6878,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
@@ -6903,7 +6888,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -6911,7 +6896,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -6919,7 +6904,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -6927,7 +6912,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -6935,7 +6920,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -6943,7 +6928,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr ""
@@ -6951,8 +6936,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -6960,7 +6945,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -6968,8 +6953,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -6977,9 +6962,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -6987,7 +6972,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -6995,7 +6980,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -7003,7 +6988,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
@@ -7011,7 +6996,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -7019,7 +7004,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -7027,7 +7012,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -7038,7 +7023,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -7046,7 +7031,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -7054,7 +7039,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
@@ -7062,7 +7047,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
@@ -7070,7 +7055,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
@@ -7078,7 +7063,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -7087,7 +7072,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -7096,7 +7081,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -7105,7 +7090,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -7113,8 +7098,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -7123,7 +7108,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
@@ -7132,7 +7117,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -7140,7 +7125,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -7148,7 +7133,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -7156,8 +7141,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -7189,7 +7174,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -7197,7 +7182,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -7213,7 +7198,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -7221,7 +7206,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -7229,8 +7214,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -7238,7 +7223,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -7246,7 +7231,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -7254,7 +7239,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -7262,7 +7247,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -7271,7 +7256,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -7280,7 +7265,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -7288,7 +7273,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -7296,7 +7281,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -7304,7 +7289,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -7312,7 +7297,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -7320,7 +7305,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -7337,7 +7322,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr ""
@@ -7362,7 +7347,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -7370,7 +7355,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 #, fuzzy
 msgid "[[<remote>:]<name>]"
 msgstr ""
@@ -7379,60 +7364,60 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, fuzzy, c-format
 msgid "error: %v"
 msgstr "Fehler: %v\n"
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7470,32 +7455,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7504,13 +7489,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7519,7 +7504,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -7527,7 +7512,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -7542,7 +7527,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7568,7 +7553,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
@@ -7586,7 +7571,7 @@ msgstr ""
 "\n"
 "lxc move <Quelle> <Ziel>\n"
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7595,13 +7580,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7624,13 +7609,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7657,74 +7642,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7732,24 +7717,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -7757,18 +7742,30 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""
+
+#, c-format
+#~ msgid "%v (interrupt two more times to force)"
+#~ msgstr "%v (zwei weitere Male unterbrechen, um zu erzwingen)"
+
+#, fuzzy, c-format
+#~ msgid "Invalid format %q"
+#~ msgstr "Ungültiges Ziel %s"
+
+#, fuzzy
+#~ msgid "Remote operation canceled by user"
+#~ msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
 #, fuzzy
 #~ msgid "[[<remote>:]<member>]"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,20 +489,20 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -515,15 +510,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -535,11 +530,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -556,15 +551,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -573,76 +568,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -651,35 +646,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -695,48 +690,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -745,119 +740,119 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "  Χρήση CPU:"
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 #, fuzzy
 msgid "CPU usage:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -866,15 +861,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -882,11 +877,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -895,70 +890,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -967,85 +962,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1061,34 +1056,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1097,33 +1092,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1131,11 +1126,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1155,114 +1150,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1278,152 +1273,152 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1431,76 +1426,76 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 #, fuzzy
 msgid "Delete network zones"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1508,113 +1503,113 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1659,16 +1654,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1676,7 +1671,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1688,31 +1683,31 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 #, fuzzy
 msgid "Disk:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 #, fuzzy
 msgid "Disks:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1720,54 +1715,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1779,78 +1774,78 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1865,7 +1860,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1873,25 +1868,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1919,80 +1914,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2007,37 +2002,37 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2047,31 +2042,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2081,26 +2076,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2110,35 +2105,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2146,11 +2141,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2162,7 +2157,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2186,16 +2181,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2207,7 +2202,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2216,30 +2211,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2247,23 +2242,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -2276,61 +2271,61 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2339,85 +2334,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2431,94 +2426,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2526,42 +2521,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2571,23 +2566,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2600,7 +2590,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2610,31 +2600,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2642,60 +2632,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2707,125 +2697,125 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 #, fuzzy
 msgid "List available network zone records"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2856,15 +2846,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2947,31 +2937,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2990,19 +2980,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -3025,11 +3015,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3038,91 +3028,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3131,7 +3121,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3139,19 +3129,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3174,7 +3164,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3182,117 +3172,117 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 #, fuzzy
 msgid "Manage network zones"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3306,45 +3296,45 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 #, fuzzy
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3354,54 +3344,54 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 #, fuzzy
 msgid "Missing key name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3411,109 +3401,109 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3529,24 +3519,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3562,265 +3552,265 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 #, fuzzy
 msgid "Network type"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3829,53 +3819,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3887,57 +3877,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3946,53 +3936,53 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4012,7 +4002,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4022,125 +4012,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4149,88 +4139,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4240,42 +4226,42 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4283,24 +4269,24 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4309,24 +4295,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4334,45 +4320,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4380,22 +4366,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4410,16 +4396,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4427,92 +4413,92 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4521,19 +4507,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4542,12 +4528,12 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4573,7 +4559,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4590,11 +4576,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4603,11 +4589,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4616,12 +4602,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4630,12 +4616,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4644,12 +4630,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4658,12 +4644,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4672,16 +4658,16 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4690,11 +4676,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4703,12 +4689,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4717,11 +4703,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4730,11 +4716,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4743,23 +4729,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4771,20 +4757,20 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4796,7 +4782,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4808,7 +4794,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4820,79 +4806,79 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4900,115 +4886,115 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5017,137 +5003,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5155,15 +5141,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5171,7 +5157,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5179,17 +5165,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "  Χρήση δικτύου:"
@@ -5208,32 +5194,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5249,23 +5235,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5280,69 +5266,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5352,69 +5338,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5424,12 +5410,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5439,12 +5425,12 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5452,7 +5438,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5460,109 +5446,109 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "  Χρήση CPU:"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5571,7 +5557,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5580,52 +5566,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5634,7 +5620,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5648,9 +5634,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5662,76 +5648,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5739,81 +5725,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5837,11 +5823,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5849,8 +5835,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5858,7 +5844,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5866,24 +5852,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5891,11 +5877,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5904,24 +5890,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5929,220 +5915,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6158,11 +6144,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6170,60 +6156,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6231,7 +6217,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6243,68 +6229,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6342,32 +6328,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6376,13 +6362,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6391,7 +6377,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6399,7 +6385,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6414,7 +6400,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6440,7 +6426,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6454,7 +6440,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6463,13 +6449,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6492,13 +6478,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6525,74 +6511,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6600,24 +6586,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6625,16 +6611,16 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -47,7 +47,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -120,7 +120,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -172,7 +172,7 @@ msgstr ""
 "###\n"
 "### Note que el nombre se muestra pero no puede ser cambiado"
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -234,7 +234,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -277,7 +277,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -316,7 +316,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -355,7 +355,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -387,7 +387,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -416,7 +416,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -445,7 +445,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -480,7 +480,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -516,7 +516,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -552,76 +552,71 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, fuzzy, c-format
 msgid "%s (%d available)"
 msgstr "%s (%d más)"
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr "%v (interrumpe dos o más tiempos a la fuerza)"
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr "(ninguno)"
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 #, fuzzy
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -629,12 +624,12 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
@@ -643,46 +638,46 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 #, fuzzy
 msgid "<alias>"
 msgstr "Aliases:"
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -691,31 +686,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, fuzzy, c-format
 msgid "Access key: %s"
 msgstr "Expira: %s"
@@ -724,7 +719,7 @@ msgstr "Expira: %s"
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -737,20 +732,20 @@ msgstr "El filtrado no está soportado aún"
 msgid "Action (defaults to GET)"
 msgstr "Accion (predeterminados a GET)"
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -758,16 +753,16 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 #, fuzzy
 msgid "Add new aliases"
 msgstr "Aliases:"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -779,11 +774,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -800,15 +795,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -817,77 +812,77 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, fuzzy, c-format
 msgid "Address: %s"
 msgstr "Expira: %s"
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Creado: %s"
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, fuzzy, c-format
 msgid "Aliases already exists: %s"
 msgstr "El dispostivo ya existe: %s"
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, fuzzy, c-format
 msgid "Architecture: %v"
 msgstr "Arquitectura: %s"
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -896,36 +891,36 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -941,48 +936,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -991,120 +986,120 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 #, fuzzy
 msgid "Both --all and instance name given"
 msgstr "Ambas: todas y el nombre del contenedor dado"
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, fuzzy, c-format
 msgid "Brand: %v"
 msgstr "Creado: %s"
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "Uso de CPU:"
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr "Uso de CPU:"
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr "CREADO"
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr "CREADO EN"
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr "Cacheado: %s"
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 #, fuzzy
 msgid "Caches:"
 msgstr "Cacheado: %s"
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1113,15 +1108,15 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1130,11 +1125,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1143,70 +1138,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1216,85 +1211,85 @@ msgstr "Certificado del cliente almacenado en el servidor: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr "Columnas"
 
@@ -1310,36 +1305,36 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1348,33 +1343,33 @@ msgstr ""
 msgid "Console log:"
 msgstr "Log de la consola:"
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1382,11 +1377,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1406,118 +1401,118 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, fuzzy, c-format
 msgid "Core %d"
 msgstr "Expira: %s"
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 #, fuzzy
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
-msgstr ""
-
-#: lxc/init.go:59
-#, fuzzy
-msgid "Create a virtual machine"
-msgstr "Copiando la imagen: %s"
-
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
-msgid "Create aliases for existing images"
 msgstr ""
 
 #: lxc/init.go:58
 #, fuzzy
+msgid "Create a virtual machine"
+msgstr "Copiando la imagen: %s"
+
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
+msgid "Create aliases for existing images"
+msgstr ""
+
+#: lxc/init.go:57
+#, fuzzy
 msgid "Create an empty instance"
 msgstr "Creando el contenedor"
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1534,153 +1529,153 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr "Creando %s"
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creando el contenedor"
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr "CONTROLADOR"
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1689,76 +1684,76 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Perfil %s creado"
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1766,113 +1761,113 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1918,16 +1913,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr "Cacheado: %s"
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
@@ -1935,7 +1930,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1947,31 +1942,31 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Uso del disco:"
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 #, fuzzy
 msgid "Disk:"
 msgstr "Uso del disco:"
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 #, fuzzy
 msgid "Disks:"
 msgstr "Uso del disco:"
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1979,55 +1974,55 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -2039,78 +2034,78 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2125,7 +2120,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -2133,26 +2128,26 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -2180,83 +2175,83 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr "Expira: %s"
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr "Expira: nunca"
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 #, fuzzy
 msgid "Export instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2271,37 +2266,37 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2311,31 +2306,31 @@ msgstr "Acepta certificado"
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2345,27 +2340,27 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 #, fuzzy
 msgid "Failed to get the new instance name"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -2375,35 +2370,35 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Acepta certificado"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2411,11 +2406,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Creando el contenedor"
@@ -2428,7 +2423,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2452,16 +2447,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2473,7 +2468,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2482,30 +2477,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2513,23 +2508,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Perfil %s creado"
@@ -2542,61 +2537,61 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2605,88 +2600,88 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 #, fuzzy
 msgid "Host interface"
 msgstr "Aliases:"
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expira: %s"
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Expira: %s"
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2700,95 +2695,95 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 #, fuzzy
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2796,44 +2791,44 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 #, fuzzy
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 #, fuzzy
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Contenedor publicado con huella digital: %s"
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2843,23 +2838,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2872,7 +2862,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -2882,32 +2872,32 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid key=value configuration: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2915,61 +2905,61 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2981,130 +2971,130 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Creado: %s"
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Arquitectura: %s"
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 #, fuzzy
 msgid "List aliases"
 msgstr "Aliases:"
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 #, fuzzy
 msgid "List all warnings"
 msgstr "Aliases:"
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -3135,16 +3125,16 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, fuzzy
 msgid "List instances"
 msgstr "Aliases:"
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -3227,32 +3217,32 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3271,20 +3261,20 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 #, fuzzy
 msgid "List warnings"
 msgstr "Aliases:"
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -3307,11 +3297,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3320,92 +3310,92 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr "Registro:"
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 #, fuzzy
 msgid "MAC address"
 msgstr "Expira: %s"
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3414,7 +3404,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3422,19 +3412,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3457,7 +3447,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3465,117 +3455,117 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Perfil %s creado"
@@ -3590,43 +3580,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3636,57 +3626,57 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 #, fuzzy
 msgid "Missing key name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nombre del contenedor es: %s"
@@ -3697,115 +3687,115 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 #, fuzzy
 msgid "Missing target network"
 msgstr "%s no es un directorio"
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3821,25 +3811,25 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3855,263 +3845,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4120,53 +4110,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4178,57 +4168,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4237,53 +4227,53 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4303,7 +4293,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr "Procesos: %d"
@@ -4313,129 +4303,129 @@ msgstr "Procesos: %d"
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Perfil %s añadido a %s"
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 #, fuzzy
 msgid "Profiles: "
 msgstr "Perfil %s creado"
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr "Público: %s"
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4444,88 +4434,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4535,43 +4521,43 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Perfil %s creado"
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4579,24 +4565,24 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4605,24 +4591,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4631,45 +4617,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4677,23 +4663,23 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 #, fuzzy
 msgid "Restart instances"
 msgstr "Aliases:"
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nombre del Miembro del Cluster"
@@ -4710,16 +4696,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4727,93 +4713,93 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Creado: %s"
@@ -4822,19 +4808,19 @@ msgstr "Creado: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4843,12 +4829,12 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4874,7 +4860,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4891,11 +4877,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4904,11 +4890,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4917,12 +4903,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4931,12 +4917,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4945,12 +4931,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4959,12 +4945,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4973,16 +4959,16 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4991,11 +4977,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5004,12 +4990,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5018,11 +5004,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5031,11 +5017,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5044,23 +5030,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5072,20 +5058,20 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -5097,7 +5083,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -5109,7 +5095,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5121,79 +5107,79 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5201,116 +5187,116 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 #, fuzzy
 msgid "State"
 msgstr "Auto actualización: %s"
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5319,137 +5305,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 #, fuzzy
 msgid "The --mode flag can't be used with --target-project"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
@@ -5458,16 +5444,16 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5475,7 +5461,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5483,17 +5469,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nombre del Miembro del Cluster"
@@ -5512,32 +5498,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
@@ -5554,23 +5540,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5585,70 +5571,70 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 #, fuzzy
 msgid "Type"
 msgstr "Expira: %s"
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Acepta certificado"
@@ -5659,69 +5645,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5731,12 +5717,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5746,12 +5732,12 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5759,7 +5745,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5767,110 +5753,110 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Acepta certificado"
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5879,7 +5865,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5888,52 +5874,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5942,7 +5928,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5956,9 +5942,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5970,90 +5956,90 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 #, fuzzy
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 #, fuzzy
 msgid "[<remote>:] [<cert>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6063,99 +6049,99 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<API path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6185,12 +6171,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6200,8 +6186,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 #, fuzzy
 msgid "[<remote>:]<instance> <template>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6211,7 +6197,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6221,27 +6207,27 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6251,12 +6237,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6267,28 +6253,28 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6298,267 +6284,267 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6578,12 +6564,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6593,73 +6579,73 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6669,7 +6655,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6684,70 +6670,70 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 #, fuzzy
 msgid "[[<remote>:]<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6785,32 +6771,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6819,13 +6805,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6834,7 +6820,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6842,7 +6828,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6857,7 +6843,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6883,7 +6869,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6897,7 +6883,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6906,13 +6892,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6935,13 +6921,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6968,74 +6954,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7043,24 +7029,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -7068,18 +7054,22 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""
+
+#, c-format
+#~ msgid "%v (interrupt two more times to force)"
+#~ msgstr "%v (interrumpe dos o más tiempos a la fuerza)"
 
 #, fuzzy
 #~ msgid "[[<remote>:]<member>]"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -44,7 +44,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -75,7 +75,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -113,7 +113,7 @@ msgstr ""
 "### Prenez note que l'empreinte digitale (fingerprint ) est affichée mais ne "
 "peut pas être modifiée"
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -165,7 +165,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgstr ""
 "### Notez que seules les règles d'entrée et de sortie, la description et les "
 "clés de configuration peuvent être modifiées ."
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -321,7 +321,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -363,7 +363,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -397,7 +397,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -418,7 +418,7 @@ msgstr ""
 "### Un exemple serait :\n"
 "###  description: Mon image personnalisée"
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -439,7 +439,7 @@ msgstr ""
 "### Un exemple serait :\n"
 "###  description: Mon image personnalisée"
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -477,7 +477,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -515,7 +515,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -553,7 +553,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -561,69 +561,64 @@ msgstr ""
 "### Ceci est une représentation yaml d'un membre du cluster.\n"
 "### Toute ligne commençant par un '#' sera ignorée."
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA node: %v)"
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, fuzzy, c-format
 msgid "%s (%d available)"
 msgstr "%s (%d de plus)"
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr "%v (interrompre encore deux fois pour forcer)"
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr "(aucun)"
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Niveau %d (type: %s): %s"
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partition %d"
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 "--console ne peut être pas utilisée tant que l'arrêt de l'instance est forcé"
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr "--console ne peut être utilisé avec --all"
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
@@ -631,11 +626,11 @@ msgstr "--empty ne peut être combiné avec le nom d'une image"
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--instance-only ne peut être utilisé lorsque la source est un snapshot"
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles ne peut pas être utilisé avec --refresh"
 
@@ -643,44 +638,44 @@ msgstr "--no-profiles ne peut pas être utilisé avec --refresh"
 msgid "--project cannot be used with the query command"
 msgstr "--project ne peut pas être utilisé avec la commande query"
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 #, fuzzy
 msgid "<alias>"
 msgstr "Alias :"
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 #, fuzzy
 msgid "<alias> <target>"
 msgstr "Cible invalide %s"
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -692,7 +687,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -702,33 +697,33 @@ msgstr ""
 msgid "<target>"
 msgstr "<cible>"
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 #, fuzzy
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, fuzzy, c-format
 msgid "Access key: %s"
 msgstr "Expire : %s"
@@ -738,7 +733,7 @@ msgstr "Expire : %s"
 msgid "Access the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr "Accusé réception d'avertissement"
 
@@ -751,20 +746,20 @@ msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 msgid "Action (defaults to GET)"
 msgstr "Action (GET par défaut)"
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -773,16 +768,16 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Création du conteneur"
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 #, fuzzy
 msgid "Add new aliases"
 msgstr "Alias :"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -802,12 +797,12 @@ msgstr ""
 "  lxc remote add un-nom https://UTILISATEUR:MOTDEPASSE@exemple.com/un/chemin "
 "--protocol=simplestreams\n"
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 #, fuzzy
 msgid "Add new trusted client"
 msgstr "Ajouter de nouveaux clients de confiance"
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -824,15 +819,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "Création du conteneur"
@@ -842,79 +837,79 @@ msgstr "Création du conteneur"
 msgid "Add roles to a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "Création du conteneur"
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, fuzzy, c-format
 msgid "Address: %s"
 msgstr "Expire : %s"
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Créé : %s"
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, fuzzy, c-format
 msgid "Alias %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, fuzzy, c-format
 msgid "Alias %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, fuzzy, c-format
 msgid "Aliases already exists: %s"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 #, fuzzy
 msgid "All projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Accepter le certificat"
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, fuzzy, c-format
 msgid "Architecture: %v"
 msgstr "Architecture : %s"
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -923,39 +918,39 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Création du conteneur"
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Création du conteneur"
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 #, fuzzy
 msgid "Attach network interfaces to instances"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -972,50 +967,50 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 #, fuzzy
 msgid "Available projects:"
 msgstr "Rendre l'image publique"
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -1024,120 +1019,120 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété : %s"
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, fuzzy, c-format
 msgid "Brand: %v"
 msgstr "Créé : %s"
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr "Octets émis"
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "CPU utilisé :"
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 #, fuzzy
 msgid "CREATED"
 msgstr "CRÉÉ À"
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr "CRÉÉ À"
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, fuzzy, c-format
 msgid "CUDA Version: %v"
 msgstr "Afficher la version du client"
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr "Créé : %s"
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 #, fuzzy
 msgid "Caches:"
 msgstr "Créé : %s"
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -1147,16 +1142,16 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1164,11 +1159,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -1179,70 +1174,70 @@ msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 "Impossible de désaffecter la clé '%s', elle n'est pas définie actuellement."
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1252,85 +1247,85 @@ msgstr "Certificat client enregistré sur le serveur : "
 msgid "Client version: %s\n"
 msgstr "Afficher la version du client"
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, fuzzy, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -1352,39 +1347,39 @@ msgstr ""
 "commandes ci-dessous.\n"
 "Pour de l'aide avec l'une des commandes, simplement les utiliser avec --help."
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 #, fuzzy
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 #, fuzzy
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
@@ -1393,33 +1388,33 @@ msgstr "Erreur lors de la lecture de la configuration : %s"
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "État : %s"
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr "Copier les alias depuis la source"
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1427,12 +1422,12 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 #, fuzzy
 msgid "Copy instances within or in between LXD servers"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1452,122 +1447,122 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 #, fuzzy
 msgid "Copy the instance without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, fuzzy, c-format
 msgid "Core %d"
 msgstr "erreur : %v"
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 #, fuzzy
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
-msgstr ""
-
-#: lxc/init.go:59
-#, fuzzy
-msgid "Create a virtual machine"
-msgstr "Copie de l'image : %s"
-
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
-msgid "Create aliases for existing images"
 msgstr ""
 
 #: lxc/init.go:58
 #, fuzzy
+msgid "Create a virtual machine"
+msgstr "Copie de l'image : %s"
+
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
+msgid "Create aliases for existing images"
+msgstr ""
+
+#: lxc/init.go:57
+#, fuzzy
 msgid "Create an empty instance"
 msgstr "Création du conteneur"
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 #, fuzzy
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
@@ -1600,168 +1595,168 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 #, fuzzy
 msgid "Create instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 #, fuzzy
 msgid "Create new instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 #, fuzzy
 msgid "Create profiles"
 msgstr "Créé : %s"
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 #, fuzzy
 msgid "Create projects"
 msgstr "Créé : %s"
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr "Création de %s"
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Création du conteneur"
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr "PILOTE"
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 #, fuzzy
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 #, fuzzy
 msgid "Delete images"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 #, fuzzy
 msgid "Delete instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -1771,81 +1766,81 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Delete instances and snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 #, fuzzy
 msgid "Delete network peerings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 #, fuzzy
 msgid "Delete projects"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 #, fuzzy
 msgid "Delete warning"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1853,114 +1848,114 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2006,17 +2001,17 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
@@ -2024,7 +2019,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2036,32 +2031,32 @@ msgstr "Désactiver l'allocation pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "  Disque utilisé :"
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Disque utilisé :"
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 #, fuzzy
 msgid "Disk:"
 msgstr "  Disque utilisé :"
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 #, fuzzy
 msgid "Disks:"
 msgstr "  Disque utilisé :"
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 #, fuzzy
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2070,57 +2065,57 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATE D'EXPIRATION"
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 #, fuzzy
 msgid "Edit instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -2135,82 +2130,82 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 #, fuzzy
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2225,7 +2220,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -2233,22 +2228,22 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Conteneur éphémère"
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, fuzzy, c-format
 msgid "Error retrieving aliases: %w"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier : %s"
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2260,7 +2255,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2297,87 +2292,87 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr "Expire : %s"
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr "N'expire jamais"
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 #, fuzzy
 msgid "Export and download images"
 msgstr "Import de l'image : %s"
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 #, fuzzy
 msgid "Export instance backups"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 #, fuzzy
 msgid "FILENAME"
 msgstr "NOM"
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2392,37 +2387,37 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2432,32 +2427,32 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 #, fuzzy
 msgid "Failed to add remote"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, fuzzy, c-format
 msgid "Failed to create %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2467,27 +2462,27 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, fuzzy, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 #, fuzzy
 msgid "Failed to get the new instance name"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2497,36 +2492,36 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 #, fuzzy
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 #, fuzzy
 msgid "Force evacuation without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2535,11 +2530,11 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation d'un pseudo-terminal"
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2553,7 +2548,7 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2577,16 +2572,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2598,7 +2593,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2607,30 +2602,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2638,23 +2633,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Clé de configuration invalide"
@@ -2669,65 +2664,65 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 #, fuzzy
 msgid "Get values for network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 #, fuzzy
 msgid "Get values for network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 #, fuzzy
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2736,90 +2731,90 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 #, fuzzy
 msgid "HOSTNAME"
 msgstr "NOM"
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 #, fuzzy
 msgid "Host interface"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 #, fuzzy
 msgid "ID"
 msgstr "PID"
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, fuzzy, c-format
 msgid "ID: %d"
 msgstr "Pid : %d"
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expire : %s"
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Expire : %s"
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr "IPv4"
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr "IPv6"
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2836,101 +2831,101 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 #, fuzzy
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 #, fuzzy
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Import de l'image : %s"
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 #, fuzzy
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2938,45 +2933,45 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 #, fuzzy
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 #, fuzzy
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Conteneur publié avec l'empreinte : %s"
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -2986,24 +2981,19 @@ msgstr "Schème d'URL invalide \"%s\" in \"%s\""
 msgid "Invalid argument %q"
 msgstr "Cible invalide %s"
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr "Certificat invalide"
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, fuzzy, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "Clé de configuration invalide"
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
-
-#: lxc/utils/table.go:65
-#, fuzzy, c-format
-msgid "Invalid format %q"
-msgstr "Cible invalide %s"
 
 #: lxc/monitor.go:71
 #, fuzzy, c-format
@@ -3015,7 +3005,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -3025,32 +3015,32 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Invalid key=value configuration: %s"
 msgstr "Clé de configuration invalide"
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3059,62 +3049,62 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 #, fuzzy
 msgid "LAST SEEN"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -3126,130 +3116,130 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Architecture : %s"
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 #, fuzzy
 msgid "List aliases"
 msgstr "Alias :"
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 #, fuzzy
 msgid "List all warnings"
 msgstr "Alias :"
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -3281,17 +3271,17 @@ msgstr ""
 msgid "List instance devices"
 msgstr "Création du conteneur"
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 #, fuzzy
 msgid "List instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, fuzzy
 msgid "List instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, fuzzy, c-format
 msgid ""
 "List instances\n"
@@ -3433,34 +3423,34 @@ msgstr ""
 "    lxc list -c n,volatile.base_image:\\BASE IMAGE\\:0,s46,volatile.eth0."
 "hwaddr:MAC"
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3479,20 +3469,20 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 #, fuzzy
 msgid "List warnings"
 msgstr "Alias :"
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -3515,11 +3505,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3528,95 +3518,95 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr "Journal : "
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 #, fuzzy
 msgid "Lower device"
 msgstr "Création du conteneur"
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 #, fuzzy
 msgid "Lower devices"
 msgstr "Création du conteneur"
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 #, fuzzy
 msgid "MAC address"
 msgstr "Expire : %s"
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr "Rendre l'image publique"
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr "Rendre l'image publique"
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3625,7 +3615,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr "Copie de l'image : %s"
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3634,22 +3624,22 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 #, fuzzy
 msgid "Manage image aliases"
 msgstr "Rendre l'image publique"
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 #, fuzzy
 msgid "Manage images"
 msgstr "Rendre l'image publique"
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3673,7 +3663,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 #, fuzzy
 msgid "Manage instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -3683,127 +3673,127 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Manage instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 #, fuzzy
 msgid "Manage network ACLs"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Nom du réseau"
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 #, fuzzy
 msgid "Manage projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 #, fuzzy
 msgid "Manage storage pools and volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Rendre l'image publique"
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Profils : %s"
@@ -3818,45 +3808,45 @@ msgstr "Profil %s ajouté à %s"
 msgid "Member %q does not have role %q"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 #, fuzzy
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, fuzzy, c-format
 msgid "Migration API failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, fuzzy, c-format
 msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
@@ -3866,57 +3856,57 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Résumé manquant."
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 #, fuzzy
 msgid "Missing key name"
 msgstr "Résumé manquant."
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -3928,119 +3918,119 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing name"
 msgstr "Résumé manquant."
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 #, fuzzy
 msgid "Missing network name"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Résumé manquant."
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 #, fuzzy
 msgid "Missing target network"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 #, fuzzy
 msgid "Mode"
 msgstr "Publié : %s"
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, fuzzy, c-format
 msgid "Model: %s"
 msgstr "Publié : %s"
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -4056,28 +4046,28 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 #, fuzzy
 msgid "Move instances within or in between LXD servers"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4093,272 +4083,272 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 #, fuzzy
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr "NOM"
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr "NON"
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, fuzzy, c-format
 msgid "Name: %v"
 msgstr "Nom : %s"
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 #, fuzzy
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Réseau utilisé :"
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 #, fuzzy
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4367,64 +4357,64 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 #, fuzzy
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 #, fuzzy
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 #, fuzzy
 msgid "Only managed networks can be modified"
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, fuzzy, c-format
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4437,57 +4427,57 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "Surcharger le mode terminal (auto, interactif ou non-interactif)"
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr "PID"
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, fuzzy, c-format
 msgid "PID: %d"
 msgstr "Pid : %d"
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr "Paquets émis"
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 #, fuzzy
 msgid "Partitions:"
 msgstr "Options :"
@@ -4497,55 +4487,55 @@ msgstr "Options :"
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 #, fuzzy
 msgid "Pause instances"
 msgstr "Création du conteneur"
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "État : %s"
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -4566,7 +4556,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr "Processus : %d"
@@ -4576,133 +4566,133 @@ msgstr "Processus : %d"
 msgid "Processing aliases failed: %s"
 msgstr "l'analyse des alias a échoué %s\n"
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s créé"
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profils : %s"
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profils : %s"
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s créé"
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr "Public : %s"
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 #, fuzzy
 msgid "Publish instances as images"
 msgstr "Création du conteneur"
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4711,93 +4701,88 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 #, fuzzy
 msgid "RESOURCE"
 msgstr "SOURCE"
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-#, fuzzy
-msgid "Remote operation canceled by user"
-msgstr "Certificat serveur rejeté par l'utilisateur"
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, fuzzy, c-format
 msgid "Removable: %v"
 msgstr "Serveur distant : %s"
@@ -4807,44 +4792,44 @@ msgstr "Serveur distant : %s"
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Clé de configuration invalide"
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 #, fuzzy
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Création du conteneur"
@@ -4854,26 +4839,26 @@ msgstr "Création du conteneur"
 msgid "Remove instance devices"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Création du conteneur"
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Création du conteneur"
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4882,26 +4867,26 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Création du conteneur"
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 #, fuzzy
 msgid "Remove trusted client"
 msgstr "Ajouter de nouveaux clients de confiance"
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4910,48 +4895,48 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 #, fuzzy
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4959,16 +4944,16 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr "Ressources :"
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 #, fuzzy
 msgid "Restart instances"
 msgstr "Création du conteneur"
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 #, fuzzy
 msgid ""
 "Restart instances\n"
@@ -4976,7 +4961,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr "Le pendant de `lxc pause` est `lxc start`."
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5009,17 +4994,17 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -5028,96 +5013,96 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr "SOURCE"
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr "STATIQUE"
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 #, fuzzy
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 #, fuzzy
 msgid "STORAGE BUCKETS"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 #, fuzzy
 msgid "STORAGE VOLUMES"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Créé : %s"
@@ -5126,21 +5111,21 @@ msgstr "Créé : %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Le serveur ne nous fait pas confiance après l'ajout de notre certificat"
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
 
@@ -5149,12 +5134,12 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5181,7 +5166,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -5199,12 +5184,12 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5213,12 +5198,12 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 #, fuzzy
 msgid "Set network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5227,12 +5212,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5241,12 +5226,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5255,12 +5240,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5269,12 +5254,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5283,17 +5268,17 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 #, fuzzy
 msgid "Set profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5302,12 +5287,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5316,12 +5301,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5330,12 +5315,12 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5344,12 +5329,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5358,23 +5343,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5386,21 +5371,21 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 #, fuzzy
 msgid "Show content of instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -5413,7 +5398,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -5427,7 +5412,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Show instance or server configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 #, fuzzy
 msgid "Show instance or server information"
 msgstr "Afficher des informations supplémentaires"
@@ -5442,86 +5427,86 @@ msgstr "Afficher les commandes moins communes"
 msgid "Show local and remote versions"
 msgstr "Afficher la version du client"
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 #, fuzzy
 msgid "Show network ACL configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 #, fuzzy
 msgid "Show network configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 #, fuzzy
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 #, fuzzy
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -5530,123 +5515,123 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 #, fuzzy
 msgid "Show the instance's last 100 log lines?"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr "Taille : %.2f Mo"
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr "Source :"
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 #, fuzzy
 msgid "Start instances"
 msgstr "Création du conteneur"
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr "Démarrage de %s"
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 #, fuzzy
 msgid "State"
 msgstr "État : %s"
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "État : %s"
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 #, fuzzy
 msgid "Stateful"
 msgstr "à suivi d'état"
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr "État : %s"
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 #, fuzzy
 msgid "Stop instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 #, fuzzy
 msgid "Stop the instance if currently running"
 msgstr "Arrêter le conteneur s'il est en cours d'exécution"
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 #, fuzzy
 msgid "Stopping instance failed!"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -5656,143 +5641,143 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Stopping the instance failed: %s"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, fuzzy, c-format
 msgid "Storage bucket key %s added"
 msgstr "Profil %s créé"
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, fuzzy, c-format
 msgid "Storage bucket key %s removed"
 msgstr "Profil %s créé"
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, fuzzy, c-format
 msgid "Storage pool %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, fuzzy, c-format
 msgid "Storage pool %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, fuzzy, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 #, fuzzy
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5800,15 +5785,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5817,7 +5802,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "Le périphérique n'existe pas"
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5827,7 +5812,7 @@ msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 "Le conteneur est en cours d'exécution, l'arrêter d'abord ou ajouter --force."
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 #, fuzzy
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
@@ -5836,13 +5821,13 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 #, fuzzy
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 "Le conteneur que vous démarrez n'est attaché à aucune interface réseau."
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5862,32 +5847,32 @@ msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 msgid "The profile device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
@@ -5904,25 +5889,25 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 #, fuzzy
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Temps d'attente du conteneur avant de le tuer"
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 #, fuzzy
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
@@ -5939,70 +5924,70 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, fuzzy, c-format
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 #, fuzzy
 msgid "Type"
 msgstr "Expire : %s"
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Accepter le certificat"
@@ -6013,70 +5998,70 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, fuzzy, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6086,12 +6071,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -6101,12 +6086,12 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -6116,7 +6101,7 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -6125,117 +6110,117 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 #, fuzzy
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 #, fuzzy
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 #, fuzzy
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 #, fuzzy
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6244,7 +6229,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, fuzzy, c-format
 msgid "Used: %v"
 msgstr "Publié : %s"
@@ -6253,53 +6238,53 @@ msgstr "Publié : %s"
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 #, fuzzy
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "erreur : %v"
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, fuzzy, c-format
 msgid "WWN: %s"
 msgstr "Nom : %s"
@@ -6308,7 +6293,7 @@ msgstr "Nom : %s"
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 #, fuzzy
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
@@ -6327,9 +6312,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr "OUI"
 
@@ -6342,17 +6327,17 @@ msgstr "Il est impossible de passer -t et -T simultanément"
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "impossible de copier vers le même nom de conteneur"
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 #, fuzzy
 msgid "You must specify a destination instance name when using --target"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -6360,7 +6345,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -6368,16 +6353,16 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Serveur distant : %s"
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 #, fuzzy
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
@@ -6385,7 +6370,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -6393,7 +6378,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -6405,7 +6390,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 #, fuzzy
 msgid "[<remote>:] [<cert>]"
 msgstr ""
@@ -6417,7 +6402,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -6425,7 +6410,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
@@ -6437,13 +6422,13 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -6451,7 +6436,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -6459,7 +6444,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -6467,7 +6452,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -6475,7 +6460,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -6495,7 +6480,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -6503,7 +6488,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -6511,7 +6496,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -6519,7 +6504,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -6527,7 +6512,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -6539,7 +6524,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
@@ -6551,7 +6536,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -6559,7 +6544,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -6571,7 +6556,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
@@ -6583,8 +6568,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6592,7 +6577,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -6600,7 +6585,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -6612,7 +6597,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -6624,7 +6609,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -6632,7 +6617,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -6640,7 +6625,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
@@ -6648,7 +6633,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -6656,7 +6641,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -6665,7 +6650,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6717,7 +6702,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -6729,7 +6714,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -6753,8 +6738,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 #, fuzzy
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
@@ -6778,7 +6763,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
@@ -6798,7 +6783,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 #, fuzzy
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
@@ -6806,7 +6791,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -6818,7 +6803,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -6826,7 +6811,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -6839,7 +6824,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -6863,7 +6848,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
@@ -6872,7 +6857,7 @@ msgstr ""
 "lxc publish [<remote>:]<container>[/<snapshot>] [<remote>:] [--"
 "alias=ALIAS...] [prop-key=prop-value...]"
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -6897,8 +6882,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -6910,7 +6895,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -6922,7 +6907,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -6934,7 +6919,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -6942,7 +6927,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -6962,9 +6947,9 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6972,7 +6957,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -6980,7 +6965,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
@@ -6988,7 +6973,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -6996,7 +6981,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -7004,9 +6989,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -7014,7 +6999,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -7022,7 +7007,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -7032,8 +7017,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -7041,7 +7026,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -7049,7 +7034,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -7059,13 +7044,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -7073,7 +7058,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
@@ -7081,7 +7066,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -7089,7 +7074,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
@@ -7097,7 +7082,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -7105,7 +7090,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
@@ -7115,7 +7100,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -7123,7 +7108,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -7131,7 +7116,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -7139,7 +7124,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -7147,7 +7132,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -7155,7 +7140,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr ""
@@ -7163,8 +7148,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -7172,7 +7157,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -7180,8 +7165,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -7189,9 +7174,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -7199,7 +7184,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -7207,7 +7192,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -7215,7 +7200,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
@@ -7223,7 +7208,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -7231,7 +7216,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -7239,7 +7224,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -7253,7 +7238,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -7261,7 +7246,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -7269,7 +7254,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
@@ -7277,7 +7262,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
@@ -7285,7 +7270,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
@@ -7293,7 +7278,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -7305,7 +7290,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -7317,7 +7302,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -7329,7 +7314,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -7337,8 +7322,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -7350,7 +7335,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
@@ -7362,7 +7347,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -7370,7 +7355,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -7378,7 +7363,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -7386,8 +7371,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -7419,7 +7404,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -7427,7 +7412,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -7443,7 +7428,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -7451,7 +7436,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -7459,8 +7444,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -7468,7 +7453,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -7476,7 +7461,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -7484,7 +7469,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -7492,7 +7477,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -7504,7 +7489,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -7516,7 +7501,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -7524,7 +7509,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -7532,7 +7517,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -7540,7 +7525,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -7548,7 +7533,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -7556,7 +7541,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -7576,7 +7561,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr ""
@@ -7604,7 +7589,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -7612,7 +7597,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 #, fuzzy
 msgid "[[<remote>:]<name>]"
 msgstr ""
@@ -7624,61 +7609,61 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr "désactivé"
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr "activé"
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr "erreur : %v"
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7716,32 +7701,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7750,13 +7735,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 #, fuzzy
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
@@ -7775,7 +7760,7 @@ msgstr ""
 "lxc info [<serveur distant>:]\n"
 "    Pour l'information du serveur LXD."
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -7783,7 +7768,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -7798,7 +7783,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7824,7 +7809,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
@@ -7850,7 +7835,7 @@ msgstr ""
 "lxc move <container>/<old snapshot name> <container>/<new snapshot name>\n"
 "    Renomme un instantané."
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7859,13 +7844,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7888,13 +7873,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7921,75 +7906,75 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 #, fuzzy
 msgid "n"
 msgstr "non"
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7997,24 +7982,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr "s'il vous plaît utilisez  `lxc profile`"
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr "espace total"
 
@@ -8022,18 +8007,30 @@ msgstr "espace total"
 msgid "unreachable"
 msgstr "inaccessible"
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr "o"
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr "oui"
+
+#, c-format
+#~ msgid "%v (interrupt two more times to force)"
+#~ msgstr "%v (interrompre encore deux fois pour forcer)"
+
+#, fuzzy, c-format
+#~ msgid "Invalid format %q"
+#~ msgstr "Cible invalide %s"
+
+#, fuzzy
+#~ msgid "Remote operation canceled by user"
+#~ msgstr "Certificat serveur rejeté par l'utilisateur"
 
 #, fuzzy
 #~ msgid "[[<remote>:]<member>]"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,7 +20,7 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -72,7 +72,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -99,7 +99,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -161,7 +161,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -209,7 +209,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -240,7 +240,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -274,7 +274,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -295,7 +295,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -316,74 +316,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -391,11 +386,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -403,44 +398,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -449,31 +444,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -482,7 +477,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -495,19 +490,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -515,15 +510,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -535,11 +530,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -556,15 +551,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -572,76 +567,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -650,35 +645,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -694,48 +689,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -744,118 +739,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -864,15 +859,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -880,11 +875,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -893,70 +888,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -965,85 +960,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1059,34 +1054,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1095,33 +1090,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1129,11 +1124,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1153,114 +1148,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1276,149 +1271,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1426,72 +1421,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1499,112 +1494,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1649,16 +1644,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1666,7 +1661,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1678,28 +1673,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1707,54 +1702,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1766,73 +1761,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1847,7 +1842,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1855,25 +1850,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1901,80 +1896,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1989,37 +1984,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2029,31 +2024,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2063,26 +2058,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2092,35 +2087,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2128,11 +2123,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2144,7 +2139,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2168,16 +2163,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2189,7 +2184,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2198,30 +2193,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2229,23 +2224,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2257,55 +2252,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2314,85 +2309,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2406,94 +2401,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2501,42 +2496,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2546,23 +2541,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2575,7 +2565,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2585,31 +2575,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2617,60 +2607,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2682,123 +2672,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2829,15 +2819,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2920,31 +2910,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2963,19 +2953,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2998,11 +2988,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3011,91 +3001,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3103,7 +3093,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3111,19 +3101,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3146,7 +3136,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3154,108 +3144,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3269,43 +3259,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3315,51 +3305,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3369,107 +3359,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3485,24 +3475,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3518,263 +3508,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3783,53 +3773,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3841,57 +3831,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3900,52 +3890,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3965,7 +3955,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3975,125 +3965,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4102,88 +4092,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4193,39 +4179,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4233,23 +4219,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4257,24 +4243,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4282,45 +4268,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4328,22 +4314,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4358,16 +4344,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4375,91 +4361,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4468,19 +4454,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4489,11 +4475,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4519,7 +4505,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4536,11 +4522,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4549,11 +4535,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4562,11 +4548,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4575,11 +4561,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4588,11 +4574,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4601,11 +4587,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4614,15 +4600,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4631,11 +4617,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4644,11 +4630,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4657,11 +4643,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4670,11 +4656,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4683,23 +4669,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4711,19 +4697,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4735,7 +4721,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4747,7 +4733,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4759,71 +4745,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4831,114 +4817,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4947,137 +4933,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5085,15 +5071,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5101,7 +5087,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5109,17 +5095,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5138,32 +5124,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5179,23 +5165,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5210,69 +5196,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5282,69 +5268,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5354,12 +5340,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5369,11 +5355,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5381,7 +5367,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5389,100 +5375,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5491,7 +5477,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5500,52 +5486,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5554,7 +5540,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5568,9 +5554,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5582,76 +5568,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5659,81 +5645,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5757,11 +5743,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5769,8 +5755,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5778,7 +5764,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5786,24 +5772,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5811,11 +5797,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5824,24 +5810,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5849,220 +5835,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6078,11 +6064,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6090,60 +6076,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6151,7 +6137,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6163,68 +6149,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6262,32 +6248,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6296,13 +6282,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6311,7 +6297,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6319,7 +6305,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6334,7 +6320,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6360,7 +6346,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6374,7 +6360,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6383,13 +6369,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6412,13 +6398,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6445,74 +6431,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6520,24 +6506,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6545,15 +6531,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -47,7 +47,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -124,7 +124,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -174,7 +174,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -231,7 +231,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -274,7 +274,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -313,7 +313,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -352,7 +352,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -384,7 +384,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -413,7 +413,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -442,7 +442,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -477,7 +477,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -513,7 +513,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -549,75 +549,70 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, fuzzy, c-format
 msgid "%s (%d available)"
 msgstr "%s (altri %d)"
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr "%v (interrompi altre due volte per forzare)"
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -625,11 +620,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -637,46 +632,46 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 #, fuzzy
 msgid "<alias>"
 msgstr "Alias:"
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -685,31 +680,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -718,7 +713,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -731,20 +726,20 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "Action (defaults to GET)"
 msgstr "Azione (default a GET)"
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -753,15 +748,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr "Aggiungi nuovi alias"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -773,11 +768,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -794,15 +789,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -811,77 +806,77 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, fuzzy, c-format
 msgid "Alias %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, fuzzy, c-format
 msgid "Alias %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr "Nome dell'alias mancante"
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, fuzzy, c-format
 msgid "Aliases already exists: %s"
 msgstr "il remote %s esiste già"
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, fuzzy, c-format
 msgid "Architecture: %v"
 msgstr "Architettura: %s"
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -890,36 +885,36 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -935,48 +930,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -985,119 +980,119 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "Utilizzo CPU:"
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 #, fuzzy
 msgid "CREATED"
 msgstr "CREATO IL"
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr "CREATO IL"
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -1106,15 +1101,15 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1122,11 +1117,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1135,70 +1130,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1208,85 +1203,85 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr "Colonne"
 
@@ -1302,34 +1297,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1338,33 +1333,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1372,11 +1367,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1396,117 +1391,117 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
-msgstr ""
-
-#: lxc/init.go:59
-#, fuzzy
-msgid "Create a virtual machine"
-msgstr "Creazione del container in corso"
-
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
-msgid "Create aliases for existing images"
 msgstr ""
 
 #: lxc/init.go:58
 #, fuzzy
+msgid "Create a virtual machine"
+msgstr "Creazione del container in corso"
+
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
+msgid "Create aliases for existing images"
+msgstr ""
+
+#: lxc/init.go:57
+#, fuzzy
 msgid "Create an empty instance"
 msgstr "Creazione del container in corso"
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 #, fuzzy
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1523,156 +1518,156 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 #, fuzzy
 msgid "Create instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 #, fuzzy
 msgid "Create new instance file templates"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creazione del container in corso"
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1681,75 +1676,75 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1757,113 +1752,113 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1909,16 +1904,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
@@ -1926,7 +1921,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1938,31 +1933,31 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Utilizzo disco:"
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 #, fuzzy
 msgid "Disk:"
 msgstr "Utilizzo disco:"
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 #, fuzzy
 msgid "Disks:"
 msgstr "Utilizzo disco:"
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1970,56 +1965,56 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DI SCADENZA"
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -2031,77 +2026,77 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2116,7 +2111,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -2124,26 +2119,26 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -2171,82 +2166,82 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 #, fuzzy
 msgid "Export instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2261,37 +2256,37 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2301,31 +2296,31 @@ msgstr "Accetta certificato"
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2335,26 +2330,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2364,36 +2359,36 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Accetta certificato"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2401,11 +2396,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Creazione del container in corso"
@@ -2418,7 +2413,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2442,16 +2437,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2463,7 +2458,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2472,30 +2467,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2503,23 +2498,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Il nome del container è: %s"
@@ -2532,60 +2527,60 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2594,86 +2589,86 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 #, fuzzy
 msgid "Host interface"
 msgstr "Creazione del container in corso"
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2687,96 +2682,96 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 #, fuzzy
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2784,43 +2779,43 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 #, fuzzy
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2830,24 +2825,19 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr "Proprietà errata: %s"
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
-
-#: lxc/utils/table.go:65
-#, fuzzy, c-format
-msgid "Invalid format %q"
-msgstr "Proprietà errata: %s"
 
 #: lxc/monitor.go:71
 #, fuzzy, c-format
@@ -2859,7 +2849,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -2869,32 +2859,32 @@ msgstr "Il nome del container è: %s"
 msgid "Invalid key=value configuration: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2903,61 +2893,61 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2969,130 +2959,130 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Architettura: %s"
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 #, fuzzy
 msgid "List aliases"
 msgstr "Alias:"
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 #, fuzzy
 msgid "List all warnings"
 msgstr "Alias:"
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -3124,16 +3114,16 @@ msgstr ""
 msgid "List instance devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, fuzzy
 msgid "List instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -3216,32 +3206,32 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3260,20 +3250,20 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 #, fuzzy
 msgid "List warnings"
 msgstr "Alias:"
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -3296,11 +3286,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3309,93 +3299,93 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 #, fuzzy
 msgid "Lower device"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 #, fuzzy
 msgid "Lower devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3404,7 +3394,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr "Il nome del container è: %s"
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3413,20 +3403,20 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3449,7 +3439,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3458,119 +3448,119 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Creazione del container in corso"
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3584,43 +3574,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3630,56 +3620,56 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 #, fuzzy
 msgid "Missing key name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Il nome del container è: %s"
@@ -3690,114 +3680,114 @@ msgstr "Il nome del container è: %s"
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 #, fuzzy
 msgid "Missing target network"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3813,25 +3803,25 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3847,263 +3837,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4112,54 +4102,54 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4171,57 +4161,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4230,54 +4220,54 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 #, fuzzy
 msgid "Pause instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4297,7 +4287,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4307,128 +4297,128 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4437,88 +4427,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4528,43 +4514,43 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Il nome del container è: %s"
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4573,24 +4559,24 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4599,24 +4585,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4625,45 +4611,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4671,23 +4657,23 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 #, fuzzy
 msgid "Restart instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Il nome del container è: %s"
@@ -4704,16 +4690,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4721,93 +4707,93 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -4816,19 +4802,19 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4837,12 +4823,12 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4868,7 +4854,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4885,11 +4871,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4898,11 +4884,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4911,11 +4897,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4924,12 +4910,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4938,11 +4924,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4951,12 +4937,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4965,16 +4951,16 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4983,11 +4969,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4996,12 +4982,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5010,11 +4996,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5023,11 +5009,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5036,23 +5022,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5064,20 +5050,20 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -5089,7 +5075,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -5101,7 +5087,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5113,79 +5099,79 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5193,117 +5179,117 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 #, fuzzy
 msgid "Start instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 #, fuzzy
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5312,139 +5298,139 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5452,15 +5438,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5468,7 +5454,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "La periferica esiste già"
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5476,17 +5462,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Il nome del container è: %s"
@@ -5506,32 +5492,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
@@ -5548,23 +5534,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5579,69 +5565,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Accetta certificato"
@@ -5652,70 +5638,70 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5725,12 +5711,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5740,12 +5726,12 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -5754,7 +5740,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5762,108 +5748,108 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accetta certificato"
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 #, fuzzy
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5872,7 +5858,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5881,52 +5867,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5935,7 +5921,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5949,9 +5935,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5963,92 +5949,92 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 #, fuzzy
 msgid "You must specify a destination instance name when using --target"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Creazione del container in corso"
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 #, fuzzy
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 #, fuzzy
 msgid "[<remote>:] [<cert>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -6058,99 +6044,99 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<API path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr "Creazione del container in corso"
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "Creazione del container in corso"
@@ -6180,12 +6166,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "Creazione del container in corso"
@@ -6195,8 +6181,8 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 #, fuzzy
 msgid "[<remote>:]<instance> <template>"
 msgstr "Creazione del container in corso"
@@ -6206,7 +6192,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "Creazione del container in corso"
@@ -6216,27 +6202,27 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -6246,12 +6232,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -6262,28 +6248,28 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "Creazione del container in corso"
@@ -6293,267 +6279,267 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Creazione del container in corso"
@@ -6573,12 +6559,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "Creazione del container in corso"
@@ -6588,73 +6574,73 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -6664,7 +6650,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
@@ -6679,70 +6665,70 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 #, fuzzy
 msgid "[[<remote>:]<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6780,32 +6766,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6814,13 +6800,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6829,7 +6815,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6837,7 +6823,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6852,7 +6838,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6878,7 +6864,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6892,7 +6878,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6901,13 +6887,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6930,13 +6916,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6963,75 +6949,75 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 #, fuzzy
 msgid "n"
 msgstr "no"
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7039,24 +7025,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -7064,18 +7050,26 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr "si"
+
+#, c-format
+#~ msgid "%v (interrupt two more times to force)"
+#~ msgstr "%v (interrompi altre due volte per forzare)"
+
+#, fuzzy, c-format
+#~ msgid "Invalid format %q"
+#~ msgstr "Proprietà errata: %s"
 
 #, fuzzy
 #~ msgid "[[<remote>:]<member>]"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -41,7 +41,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -71,7 +71,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -95,7 +95,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -107,7 +107,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -153,7 +153,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -213,7 +213,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -265,7 +265,7 @@ msgstr ""
 "### Note that only the ingress and egress rules, description and "
 "configuration keys can be changed."
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -309,7 +309,7 @@ msgstr ""
 "###\n"
 "### Note that the listen_address and location cannot be changed."
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -353,7 +353,7 @@ msgstr ""
 "###\n"
 "### Note that the listen_address and location cannot be changed."
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -383,7 +383,7 @@ msgstr ""
 "### Note that the name, target_project, target_network and status fields "
 "cannot be changed."
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -407,7 +407,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,7 +431,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -467,7 +467,7 @@ msgstr ""
 "###\n"
 "### Note that only the configuration can be changed."
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -505,7 +505,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -540,7 +540,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -548,69 +548,63 @@ msgstr ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, オンライン: %v, NUMA ノード: %v)"
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr "%s (%d個使用可能)"
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-"%v (強制的に中断したい場合はあと2回Ctrl-Cを入力/SIGINTを送出してください)"
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr "(none)"
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- レベル %d (タイプ: %s): %s"
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr "- パーティション %d"
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- ポート %d (%s)"
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "インスタンスの強制シャットダウンの際は --console は使えません"
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr "--console と --all は同時に指定できません"
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
@@ -618,11 +612,11 @@ msgstr "--empty はイメージ名と同時に指定できません"
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--instance-only はコピー元がスナップショットの場合は指定できません"
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles と --refresh は同時に指定できません"
 
@@ -630,44 +624,44 @@ msgstr "--no-profiles と --refresh は同時に指定できません"
 msgid "--project cannot be used with the query command"
 msgstr "--project は query コマンドでは使えません"
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr "<alias>"
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr "<alias> <target>"
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -677,31 +671,31 @@ msgstr ""
 msgid "<target>"
 msgstr "<target>"
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr "アクセスキー（空白の場合自動生成）"
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr "アクセスキー: %s"
@@ -710,7 +704,7 @@ msgstr "アクセスキー: %s"
 msgid "Access the expanded configuration"
 msgstr "拡張した設定を表示する"
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr "警告を確認します"
 
@@ -723,19 +717,19 @@ msgstr "%q はこのツールではサポートされていません"
 msgid "Action (defaults to GET)"
 msgstr "使用するHTTPのメソッド (デフォルト: GET)"
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr "ネットワークゾーンレコードのエントリを追加します"
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr "ネットワークゾーンレコードにエントリを追加します"
 
@@ -743,15 +737,15 @@ msgstr "ネットワークゾーンレコードにエントリを追加します
 msgid "Add instance devices"
 msgstr "インスタンスにデバイスを追加します"
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr "新たにエイリアスを追加します"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr "新たにリモートサーバを追加します"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -770,11 +764,11 @@ msgstr ""
 "  lxc remote add some-name https://LOGIN:PASSWORD@example.com/some/path --"
 "protocol=simplestreams\n"
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr "新たに信頼済みのクライアントを追加します"
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -802,15 +796,15 @@ msgstr ""
 "使ったトークンは無効化されます。\n"
 "証明書と同様に、トークンも 1 つ以上のプロジェクトに制限できます。\n"
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr "フォワードにポートを追加します"
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr "ロードバランサーにポートを追加します"
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr "インスタンスにプロファイルを追加します"
 
@@ -818,76 +812,76 @@ msgstr "インスタンスにプロファイルを追加します"
 msgid "Add roles to a cluster member"
 msgstr "クラスターメンバーにロールを追加します"
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr "ACLにルールを追加します"
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr "アドレス: %s"
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード（もしくはトークン）:"
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "管理者秘密鍵: %s"
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr "エイリアス %s は既に存在します"
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr "エイリアス %s は存在しません"
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr "エイリアスを指定してください"
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, fuzzy, c-format
 msgid "Aliases already exists: %s"
 msgstr "エイリアス %s は既に存在します"
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr "すべてのサーバーアドレスが利用できません"
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr "アーキテクチャ: %v"
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -897,35 +891,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr "クラスターメンバーにグループの組を割り当てます"
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr "インスタンスにプロファイルを割り当てます"
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr "インスタンスにネットワークインターフェースを追加します"
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr "プロファイルにネットワークインターフェースを追加します"
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr "新たなネットワークインターフェースをインスタンスに追加します"
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr "新たにストレージボリュームをインスタンスに追加します"
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
@@ -945,48 +939,48 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr "オートネゴシエーション: %v"
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr "自動更新は pull モードのときのみ有効です"
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr "BASE IMAGE"
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -997,118 +991,118 @@ msgstr ""
 "デバイスを上書きする際の書式が不適切です。次のような形式で指定してください "
 "<device>,<key>=<value>: %s"
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr "ボンディング:"
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr "--all とインスタンス名を両方同時に指定することはできません"
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr "ブランド: %v"
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr "ブリッジ:"
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr "CANCELABLE"
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr "COUNT"
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr "CPUs (%s):"
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr "CREATED"
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr "CREATED AT"
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "CUDA バージョン: %v"
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr "キャッシュ済: %s"
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr "キャッシュ:"
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1118,15 +1112,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr "--fast と --columns は同時に指定できません"
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr "--project と --all-project は同時に指定できません"
 
@@ -1134,11 +1128,11 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1147,11 +1141,11 @@ msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr "使用する Candid ドメイン"
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1159,64 +1153,64 @@ msgstr ""
 "デバイス %q の設定を上書きできません: プロファイルのデバイス内にデバイスが見"
 "つかりません"
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "コピー先のサーバーがクラスターに属していない場合は --destination-target は指"
 "定できません"
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "コピー元のサーバーがクラスターに属していない場合は --target は指定できません"
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr "設定キーを設定できません: %s"
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr "トークンを使っている時はメトリクスタイプの証明書を使えません"
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr "カード %d:"
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr "カード: %s (%s)"
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "%s に対する証明書追加トークンが削除されました"
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr "Chassis"
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1225,85 +1219,85 @@ msgstr "クライアント証明書がサーバに信頼されました:"
 msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr "クラスターグループ %s が削除されました"
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "クラスターグループ %s は現在 %s に適用されていません"
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "クラスタグループ名 %s を %s に変更しました"
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr "クラスターメンバー %s がクラスターグループ %s に追加されました"
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -1323,34 +1317,34 @@ msgstr ""
 "LXD の機能のすべてが、以下の色々なコマンドから操作できます。\n"
 "コマンドのヘルプは、--help をコマンドに付けて実行するだけです。"
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "圧縮アルゴリズムを指定します: (圧縮しない場合は `none`)"
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "使用する圧縮アルゴリズムを指定します (圧縮しない場合は none)"
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
@@ -1359,33 +1353,33 @@ msgstr "設定の構文エラー: %s"
 msgid "Console log:"
 msgstr "コンソールログ:"
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr "コントロール: %s (%s)"
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr "ステートフルなインスタンスをステートレスにコピーします"
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr "ソースからエイリアスをコピーしました"
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr "サーバ間でイメージをコピーします"
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1397,11 +1391,11 @@ msgstr ""
 "自動更新フラグは、このイメージを最新に保つようにサーバに指示します。\n"
 "ソースはエイリアスで、かつパブリックである必要があります。"
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr "LXD サーバ内で、またはサーバ間でインスタンスをコピーします"
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1432,114 +1426,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "プロファイルに継承されたデバイスをコピーし、設定キーを上書きします"
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr "ストレージボリュームをコピーします"
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr "インスタンスをコピーします。スナップショットはコピーしません"
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr "仮想マシンイメージをコピーします"
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr "コア %d"
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "証明書のファイルパスが見つかりません: %s"
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "証明書ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr "一致するエントリを見つけられませんでした"
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr "クラスターグループを作成します"
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr "仮想マシンを作成します"
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr "既存のイメージに対するエイリアスを作成します"
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr "空のインスタンスを作成"
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
@@ -1559,149 +1553,149 @@ msgstr ""
 "--stateful を指定すると、LXD はインスタンスの実行状態（プロセスのメモリ状態、"
 "TCPコネクション、など…を含む）を保存しようとします。"
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr "イメージからインスタンスを作成します"
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr "新たにインスタンスのファイルテンプレートを作成します"
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr "新たにネットワーク ACL を作成します"
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr "新たにネットワークフォワードを作成します"
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr "新たにネットワークロードバランサーを作成します"
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr "新たにネットワークピアリングを作成します"
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr "新たにネットワークゾーンを作成します"
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr "新たにネットワークを作成します"
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr "プロジェクトを作成します"
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr "ストレージプールを作成します"
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr "%s を作成中"
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr "現在の VF 数: %d"
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr "DISK USAGE"
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr "DRM:"
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr "バックグラウンドの操作を削除します（キャンセルを試みます）"
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr "クラスタグループを削除します"
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr "イメージのエイリアスを削除します"
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr "イメージを削除します"
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr "インスタンスのファイルテンプレートを削除します"
 
@@ -1709,72 +1703,72 @@ msgstr "インスタンスのファイルテンプレートを削除します"
 msgid "Delete instances and snapshots"
 msgstr "インスタンスとスナップショットを削除します"
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr "ストレージバケットからキーを削除します"
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr "ネットワーク ACL を削除します"
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr "ネットワークフォワードを削除します"
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr "ネットワークロードバランサーを削除します"
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr "ネットワークピアリングを削除します"
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr "ネットワークゾーンレコードを削除します"
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr "ネットワークゾーンを削除します"
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr "ネットワークを削除します"
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr "プロジェクトを削除します"
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr "ストレージバケットを削除します"
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr "警告を削除します"
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1782,112 +1776,112 @@ msgstr "警告を削除します"
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr "説明"
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr "インスタンスからネットワークインターフェースを取り外します"
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
@@ -1936,18 +1930,18 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr "プロファイルのデバイスは個々のインスタンスでは取得できません"
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
 "でした"
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr "このプラットフォーム上ではディレクトリのインポートは利用できません"
 
@@ -1955,7 +1949,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -1967,28 +1961,28 @@ msgstr "擬似端末の割り当てを無効にします"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr "ディスク %d:"
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr "ディスク:"
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr "ディスク:"
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
@@ -1996,32 +1990,32 @@ msgstr "--force を使う際にユーザーの確認を必要としない"
 msgid "Don't show progress information"
 msgstr "進捗情報を表示しません"
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr "Down delay"
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr "ドライバ: %v (%v)"
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr "ENTRIES"
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr "EPHEMERAL"
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr "EXPIRES AT"
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr "EXPIRY DATE"
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2029,23 +2023,23 @@ msgstr ""
 "ファイル転送のサーバ側の初期処理はキャンセルできません（強制的に中断するには"
 "あと2回行ってください）"
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr "クラスタグループを編集します"
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr "インスタンスのファイルテンプレートを編集します"
 
@@ -2057,75 +2051,75 @@ msgstr "インスタンスのメタデータファイルを編集します"
 msgid "Edit instance or server configurations as YAML"
 msgstr "インスタンスもしくはサーバの設定をYAMLファイルで編集します"
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr "ネットワーク ACL をYAMLで編集します"
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr "ネットワーク設定をYAMLで編集します"
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr "ネットワークフォワード設定をYAMLで編集します"
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr "ネットワークロードバランサー設定をYAMLで編集します"
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr "ネットワークピア設定をYAMLで編集します"
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr "ネットワークゾーン設定をYAMLで編集します"
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr "ネットワークゾーンレコードをYAMLで編集します"
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr "プロジェクト設定をYAMLで編集します"
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 "'%s' 中のカラムエントリが空です (カラムの指定に空文字列が指定されています)"
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 "クラスタリングで動作していないLXDサーバ上でクラスタリングを有効にします"
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2149,7 +2143,7 @@ msgstr ""
 "  これは 'lxc config get core.https_address' コマンドでチェックできます。\n"
 "  まだ使用可能でない場合は、アドレスを設定することもできます。"
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr "TTLを指定します"
 
@@ -2157,25 +2151,25 @@ msgstr "TTLを指定します"
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "環境変数を設定します (例: HOME=/home/foo)"
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr "Ephemeral インスタンス"
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, fuzzy, c-format
 msgid "Error retrieving aliases: %w"
 msgstr "イメージの取得中: %s"
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr "クラスターのメンバーを待避させます"
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "クラスターメンバーを待避させています: %s"
@@ -2214,25 +2208,25 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr "失効日時"
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr "失効日時: %s"
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr "失効日時: 失効しない"
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr "イメージをエクスポートしてダウンロードします"
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2242,56 +2236,56 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr "インスタンスのバックアップをエクスポートします"
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr "FAILURE DOMAIN"
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2306,37 +2300,37 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr "証明書追加トークンのトークン変換操作に失敗しました: %w"
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
@@ -2346,31 +2340,31 @@ msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr "リモートの追加に失敗しました"
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
@@ -2380,26 +2374,26 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr "新しいインスタンス名が取得できません"
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗しました: %v"
@@ -2409,35 +2403,35 @@ msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗し
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr "特定の待避アクションを強制します"
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
 
@@ -2445,11 +2439,11 @@ msgstr "ユーザーの確認なしで強制的に待避させます"
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr "インスタンスを強制停止します"
 
@@ -2461,7 +2455,7 @@ msgstr "稼働中のインスタンスを強制的に削除します"
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2500,16 +2494,16 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
@@ -2521,7 +2515,7 @@ msgstr "フォーマット (json|pretty|yaml)"
 msgid "Format (man|md|rest|yaml)"
 msgstr "フォーマット (man|md|rest|yaml)"
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr "Forward delay"
 
@@ -2530,30 +2524,30 @@ msgstr "Forward delay"
 msgid "Found alias %q references an argument outside the given number"
 msgstr "エイリアス %q が指定した番号以外の引数を参照しているのが見つかりました"
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr "空き: %v"
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr "クロック数: %vMhz"
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr "GPU:"
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr "GPUs:"
 
@@ -2561,23 +2555,23 @@ msgstr "GPUs:"
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr "ネットワークのランタイム情報を取得します"
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr "クラスターメンバーの設定値を取得します"
 
@@ -2589,55 +2583,55 @@ msgstr "デバイスの設定値を取得します"
 msgid "Get values for instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定値を取得します"
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr "ネットワーク ACL の設定値を取得します"
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr "ネットワークの設定値を取得します"
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr "ネットワークフォワードの設定値を取得します"
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定値を取得します"
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr "ネットワークピアの設定値を取得します"
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr "ネットワークゾーンの設定値を取得します"
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定値を取得します"
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr "プロジェクトの設定値を取得します"
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr "ストレージバケットの設定値を取得します"
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %q と一致しません"
@@ -2646,88 +2640,88 @@ msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %
 msgid "Group ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のグループ ID (GID) (デフォルト 0)"
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr "ホストインターフェース"
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr "ID"
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr "ID: %d"
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr "IMAGES"
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr "IP アドレス"
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr "IP アドレス:"
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr "IPV6"
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr "ISSUE DATE"
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 #, fuzzy
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -2743,72 +2737,72 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr "コピー中にファイルが更新された場合のエラーを無視します"
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr "イメージのコピーが成功しました!"
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr "イメージの失効日（フォーマット: rfc3339）"
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
 "ます。"
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2819,25 +2813,25 @@ msgstr ""
 "ディレクトリのインポートは Linux 上でのみ可能で、root で実行する必要がありま"
 "す。"
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr "イメージをイメージストアにインポートします"
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr "インスタンスのインポート中: %s"
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr "Infiniband:"
 
@@ -2845,42 +2839,42 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "インスタンスは以下のフィンガープリントで publish されます: %s"
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -2890,25 +2884,20 @@ msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
 msgid "Invalid argument %q"
 msgstr "不正な引数 %q"
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr "不正な証明書です"
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "'%s' は正しくない設定項目 (key) です (%s 中の)"
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 "不正な設定項目のカラムフォーマットです (フィールド数が多すぎます): '%s'"
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
-msgstr "不正なフォーマット %q"
 
 #: lxc/monitor.go:71
 #, c-format
@@ -2920,7 +2909,7 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -2930,36 +2919,36 @@ msgstr "不正なインスタンスのパス: %q"
 msgid "Invalid key=value configuration: %s"
 msgstr "不適切な キー=値 の設定: %s"
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 "'%s' は最大幅の値として不正です (-1 もしくは 0 もしくは正の整数でなくてはなり"
 "ません) ('%s' 中の)"
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr "'%s' は最大幅の値として不正です (整数でなくてはなりません) ('%s' 中の)"
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr "不適切な新しいスナップショット名"
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のスナップショット名はソースと同じでな"
 "ければいけません"
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
@@ -2969,60 +2958,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr "IsSM: %s (%s)"
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr "LAST SEEN"
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr "LIMIT"
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr "LISTEN ADDRESS"
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -3036,112 +3025,112 @@ msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
 "を使います。"
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr "リンクを検出: %v"
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "リンクスピード: %dMbit/s (%s duplex)"
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr "DHCP のリースを一覧表示します"
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr "エイリアスを一覧表示します"
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr "有効な証明書追加トークンをすべて一覧表示します"
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr "有効なクラスターへの join トークンをすべて一覧表示します"
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr "クラスタグループをすべて一覧表示します"
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr "クラスタのメンバをすべて一覧表示します"
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr "警告を一覧表示します"
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr "利用可能なネットワーク ACL を一覧表示します"
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr "利用可能なネットワーク ACL を一覧表示します"
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr "利用可能なネットワークフォワードを一覧表示します"
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr "利用可能なネットワークロードバランサーを一覧表示します"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr "利用可能なネットワークピアを一覧表示します"
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr "利用可能なネットワークゾーンを一覧表示します"
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr "利用可能なネットワークゾーンレコードを一覧表示します"
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr "利用可能なネットワークゾーンを一覧表示します"
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr "利用可能なネットワークを一覧表示します"
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr "利用可能なストレージプールを一覧表示します"
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr "バックグラウンド操作を一覧表示します"
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr "イメージのエイリアスを一覧表示します"
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3152,11 +3141,11 @@ msgstr ""
 "指定するフィルタはイメージのハッシュ値の一部でもイメージのエイリアスの一部で"
 "も構いません。\n"
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr "イメージを一覧表示します"
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -3211,15 +3200,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr "インスタンスのデバイスを一覧表示します"
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr "インスタンスのファイルテンプレートを一覧表示します"
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -3379,31 +3368,31 @@ msgstr ""
 "  MAXWIDTH: カラムの最大幅 (結果がこれより長い場合は切り詰められます)\n"
 "  デフォルトは -1 (制限なし)。0 はカラムのヘッダサイズに制限します。"
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr "証明書の使用を制限するプロジェクトのリスト"
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr "プロジェクトを一覧表示します"
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr "ストレージバケットの鍵を一覧表示します"
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3436,19 +3425,19 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr "信頼済みクライアントを一覧表示します"
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr "警告を一覧表示します"
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -3489,11 +3478,11 @@ msgstr ""
 "    u - UUID\n"
 "    t - タイプ"
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -3502,91 +3491,91 @@ msgstr "ロケーション: %s"
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr "ログ:"
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr "Lower device"
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr "Lower devices"
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr "MAC アドレス"
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr "MAC アドレス: %s"
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr "MAD: %s (%s)"
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr "MANAGED"
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr "MEMBERS"
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr "MEMORY USAGE"
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr "MEMORY USAGE%"
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr "MESSAGE"
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr "MII 監視頻度"
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr "MII 状態"
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr "MTU"
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr "MTU: %d"
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr "イメージを public にする"
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr "イメージを public にする"
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr "ネットワークを管理し、インスタンスをネットワークに接続します"
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr "クラスタグループを管理します"
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr "クラスタのメンバを管理します"
 
@@ -3594,7 +3583,7 @@ msgstr "クラスタのメンバを管理します"
 msgid "Manage cluster roles"
 msgstr "クラスタロールを管理します"
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr "コマンドのエイリアスを管理します"
 
@@ -3602,19 +3591,19 @@ msgstr "コマンドのエイリアスを管理します"
 msgid "Manage devices"
 msgstr "デバイスを管理します"
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr "イメージのエイリアスを管理します"
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr "イメージを管理します"
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3650,7 +3639,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr "インスタンスやサーバの設定を管理します"
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr "インスタンスのファイルテンプレートを管理します"
 
@@ -3658,112 +3647,112 @@ msgstr "インスタンスのファイルテンプレートを管理します"
 msgid "Manage instance metadata files"
 msgstr "インスタンスのメタデータファイルを管理します"
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr "ネットワーク ACL ルールを管理します"
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr "ネットワーク ACL を管理します"
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr "ネットワークフォワードのポートを管理します"
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr "ネットワークフォワードを管理します"
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr "ネットワークロードバランサーのバックエンドを管理します"
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr "ネットワークロードバランサーのポートを管理します"
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr "ネットワークロードバランサーを管理します"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr "ネットワークピアリングを管理します"
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr "ネットワークゾーンレコードのエントリを管理します"
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr "ネットワークゾーンレコードを管理します"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr "ネットワークゾーンを管理します"
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr "プロファイルを管理します"
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr "プロジェクトを管理します"
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr "ストレージバケットの鍵を管理します"
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr "ストレージバケットの鍵を管理します。"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr "ストレージバケットを管理します"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr "ストレージバケットを管理します。"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr "ストレージプール、ストレージボリュームを管理します"
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr "ストレージボリュームを管理します"
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
 "プレフィックスで指定しない限りは、ボリュームに対する操作はすべて \"カスタム"
 "\" (ユーザが作成した) ボリュームに対して行われます。"
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr "リモートサーバのリストを管理します"
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr "信頼済みのクライアントを管理します"
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr "警告を管理します"
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr "VF の最大数: %d"
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr "Mdevプロファイル:"
 
@@ -3777,43 +3766,43 @@ msgstr "メンバー %q はすでにロール %q を持っています"
 msgid "Member %q does not have role %q"
 msgstr "メンバー %q はロール %q を持っていません"
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr "メンバ %s の join トークン:"
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr "メンバ %s が削除されました"
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr "マイグレーション API が失敗しました: %w"
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
@@ -3823,51 +3812,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr "ログメッセージの最小レベル（pretty フォーマット使用時のみ利用可能）"
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr "バケット名を指定する必要があります"
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr "証明書のフィンガープリントがありません"
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr "鍵の名前を指定する必要があります"
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr "リッスンアドレスを指定する必要があります"
 
@@ -3877,107 +3866,107 @@ msgstr "リッスンアドレスを指定する必要があります"
 msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr "ネットワーク ACL 名を指定する必要があります"
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr "ネットワーク名を指定する必要があります"
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr "ネットワークゾーン名を指定する必要があります"
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr "ネットワークゾーンレコード名を指定する必要があります"
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr "ピア名を指定する必要があります"
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr "作成するネットワーク名を指定する必要があります"
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr "モード"
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr "モデル: %s"
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr "モデル: %v"
@@ -3996,26 +3985,26 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr "LXD サーバ内もしくはサーバ間でインスタンスを移動します"
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4042,195 +4031,195 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 "複数のポートにマッチしました。すべて削除するには --force を指定してください"
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 "複数のルールにマッチしました。すべて削除するには --force を指定してください"
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr "ディレクトリからのインポートは root で実行する必要があります"
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr "NAME"
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr "NETWORK ZONES"
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr "NETWORKS"
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr "NIC:"
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr "NICs:"
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr "NO"
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr "NUMA ノード: %v"
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr "NUMA ノード:\n"
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr "NVIDIA 情報:"
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr "名前"
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr "名前: %v"
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr "ネットワーク %s を作成しました"
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr "ネットワーク %s を削除しました"
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr "ネットワーク %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr "ネットワーク ACL %s を作成しました"
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr "ネットワーク ACL %s を削除しました"
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "ネットワーク ACL 名 %s を %s に変更しました"
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr "ネットワークゾーン %s を作成しました"
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr "ネットワークゾーン %s を削除しました"
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr "ネットワークフォワード %s を作成しました"
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr "ネットワークフォワード %s を削除しました"
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr "ネットワークロードバランサー %s を作成しました"
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr "ネットワークロードバランサー %s を削除しました"
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr "ネットワーク名:"
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr "ネットワークピア %s を作成しました"
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr "ネットワークピア %s を削除しました"
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr "ネットワークピア %s は想定外のステータスです %q"
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -4238,72 +4227,72 @@ msgstr ""
 "ネットワークピア %s はピアリング状態です (ピアネットワーク上で相互ピアリング"
 "を完了させてください)"
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr "ネットワークゾーンレコード %s を作成しました"
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr "ネットワークゾーンレコード %s を削除しました"
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr "新しいエイリアスを定義する"
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr "メンバー %s に対する証明書追加トークンがリモートにありません: %s"
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 "メンバー %s に対するクラスターへの join トークンがリモート %s にありません"
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr "マッチするバックエンドが見つかりません"
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr "マッチするポートが見つかりません"
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr "マッチするルールが見つかりません"
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
@@ -4312,53 +4301,53 @@ msgstr "コピー先のボリュームに対するストレージプールが指
 msgid "No value found in %q"
 msgstr "%q に設定する値が指定されていません"
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr "スナップショット名ではありません"
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr "OVN:"
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr "管理対象のネットワークのみ変更できます"
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -4370,57 +4359,57 @@ msgstr "プロジェクトを指定します"
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "ターミナルモードを上書きします (auto, interactive, non-interactive)"
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr "PCI アドレス: %v"
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr "PEER"
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr "PID"
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr "PID: %d"
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr "PORTS"
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr "送信パケット"
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr "パーティション:"
 
@@ -4429,52 +4418,52 @@ msgstr "パーティション:"
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr "インスタンスを一時停止します"
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "別のサーバアドレスを指定してください（空の場合は中止）:"
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr "クライアント名を入力してください: "
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr "ポートタイプ: %s"
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -4496,7 +4485,7 @@ msgstr "レスポンスをそのまま表示します"
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
@@ -4506,125 +4495,125 @@ msgstr "プロセス数: %d"
 msgid "Processing aliases failed: %s"
 msgstr "エイリアスの処理が失敗しました: %s"
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr "製品名: %v (%v)"
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "プロファイル %s は %s に適用されていません"
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "プロファイル %s が %s から削除されました"
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr "新しいイメージに適用するプロファイル"
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr "新しいインスタンスに適用するプロファイル"
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr "移動先のインスタンスに適用するプロファイル"
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr "プロファイル:"
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr "プロファイル: "
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr "プロジェクト %s を作成しました"
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr "プロジェクト %s を削除しました"
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr "パブリック: %s"
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr "インスタンスをイメージとして出力します"
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -4633,88 +4622,84 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr "RESOURCE"
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr "ROLE"
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr "ROLES"
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr "読み取り専用: %v"
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr "リモート操作がユーザによってキャンセルされました"
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr "リムーバブルディスク: %v"
@@ -4724,39 +4709,39 @@ msgstr "リムーバブルディスク: %v"
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr "クラスタからメンバを削除します"
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr "マッチするポートをすべて削除します"
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr "マッチするルールをすべて削除します"
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr "ネットワークゾーンレコードからエントリを削除します"
 
@@ -4764,23 +4749,23 @@ msgstr "ネットワークゾーンレコードからエントリを削除しま
 msgid "Remove instance devices"
 msgstr "インスタンスのデバイスを削除します"
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr "フォワードからポートを削除します"
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr "ロードバランサーからポートを削除します"
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -4788,24 +4773,24 @@ msgstr "リモートサーバを削除します"
 msgid "Remove roles from a cluster member"
 msgstr "クラスタメンバからロールを削除します"
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr "ACL からルールを削除します"
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr "信頼済みクライアントを削除します"
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr "クラスタグループの名前を変更します"
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr "クラスタメンバの名前を変更します"
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr "エイリアスの名前を変更します"
 
@@ -4813,46 +4798,46 @@ msgstr "エイリアスの名前を変更します"
 msgid "Rename instances and snapshots"
 msgstr "インスタンスまたはインスタンスのスナップショットの名前を変更します"
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr "ネットワーク ACL 名を変更します"
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 "ストレージボリューム名とストレージボリュームのスナップショット名を変更します"
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr "レンダー: %s (%s)"
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
@@ -4860,15 +4845,15 @@ msgstr "クラスターメンバーに join するためのトークンを要求
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr "リソース:"
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr "インスタンスを再起動します"
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4878,7 +4863,7 @@ msgstr ""
 "\n"
 "\"lxc pause\" の反対のコマンドは \"lxc start\" です。"
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr "クラスターメンバーをリストアします"
 
@@ -4896,16 +4881,16 @@ msgstr ""
 "\n"
 "--stateful オプションを指定すると、インスタンスの実行状態もリストアします。"
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr "クラスターメンバーをリストアしています: %s"
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 
@@ -4913,91 +4898,91 @@ msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 msgid "Retrieve the instance's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr "証明書追加トークンを失効（Revoke）させます"
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr "クラスターメンバーに join するためのトークンを失効（Revoke）させます"
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr "ロール（admin または read-only）"
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr "すべてのインスタンスに対してコマンドを実行します"
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr "SEVERITY"
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr "SIZE"
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr "SNAPSHOTS"
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr "SOURCE"
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr "STATIC"
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr "STATUS"
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr "STORAGE BUCKETS"
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr "STORAGE VOLUMES"
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr "STP"
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr "秘密鍵（空白の場合自動生成）"
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr "秘密鍵: %s"
@@ -5006,20 +4991,20 @@ msgstr "秘密鍵: %s"
 msgid "Send a raw query to LXD"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 #, fuzzy
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
 
@@ -5028,11 +5013,11 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -5066,7 +5051,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
@@ -5087,11 +5072,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr "ネットワーク ACL の設定項目を設定します"
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -5104,11 +5089,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr "ネットワークの設定項目を設定します"
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5121,11 +5106,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5138,11 +5123,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5155,11 +5140,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr "ネットワークピアの設定を行います"
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5172,11 +5157,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr "ネットワークゾーンの設定を行います"
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5189,15 +5174,15 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を行います"
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr "プロファイルの設定項目を設定します"
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5210,11 +5195,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5227,11 +5212,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc project set [<remote>:]<project> <key> <value>"
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr "ストレージバケットの設定項目を設定します"
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5244,11 +5229,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage bucket set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr "ストレージプールの設定項目を設定します"
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5261,11 +5246,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5278,23 +5263,23 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -5307,19 +5292,19 @@ msgstr "デバッグメッセージをすべて表示します"
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr "クラスタグループの設定を表示します"
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr "インスタンスのファイルテンプレートの内容を表示します"
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr "クラスタメンバの詳細を表示します"
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr "バックグラウンド操作の詳細を表示します"
 
@@ -5331,7 +5316,7 @@ msgstr "すべてのプロジェクトのイベントを表示します"
 msgid "Show full device configuration"
 msgstr "デバイスの設定をすべて表示します"
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
@@ -5343,7 +5328,7 @@ msgstr "インスタンスのメタデータファイルを表示します"
 msgid "Show instance or server configurations"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr "インスタンスもしくはサーバの情報を表示します"
 
@@ -5355,71 +5340,71 @@ msgstr "全てのコマンドを表示します (主なコマンドだけでは�
 msgid "Show local and remote versions"
 msgstr "ローカルとリモートのバージョンを表示します"
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr "ネットワーク ACL の設定を表示します"
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr "ネットワーク ACL ログを表示します"
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr "ネットワークの設定を表示します"
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr "ネットワークフォワードの設定を表示します"
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr "ネットワークロードバランサーの設定を表示します"
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr "ネットワークピアの設定を表示します"
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr "ネットワークゾーンの設定を表示します"
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr "ストレージバケットの設定を表示する"
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr "ストレージバケットの鍵の設定を表示する"
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -5427,114 +5412,114 @@ msgstr "デフォルトのリモートを表示します"
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr "インスタンスログの最後の 100 行を表示しますか?"
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr "サーバで使用可能なリソースを表示します"
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr "ストレージプールで利用可能なリソースを表示します"
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr "使用量と空き容量を byte で表示します"
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr "信頼済みクライアントの設定を表示します"
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr "クラスターメンバーについての情報を表示します"
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr "イメージについての情報を表示します"
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr "ストレージプールの情報を表示します"
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr "警告を表示します"
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr "サイズ: %.2fMB"
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr "ソケット %d:"
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr "一部のインスタンスで %s が失敗しました"
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr "取得元:"
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr "インスタンスを起動します"
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr "%s を起動中"
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr "状態"
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr "状態: %s"
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr "ステートフル"
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr "状態: %s"
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr "インスタンスを停止します"
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr "実行中の場合、インスタンスを停止します"
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr "インスタンスの停止に失敗しました！"
 
@@ -5543,137 +5528,137 @@ msgstr "インスタンスの停止に失敗しました！"
 msgid "Stopping the instance failed: %s"
 msgstr "インスタンスの停止に失敗しました: %s"
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr "ストレージバケット %s を作成しました"
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr "ストレージバケット %s を削除しました"
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr "ストレージバケットの鍵 %s を作成しました"
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr "ストレージバケットの鍵 %s を削除しました"
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr "ストレージプール %s を作成しました"
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr "ストレージプール %s を削除しました"
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr "ストレージボリュームのコピーが成功しました!"
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr "インスタンスの状態を保存します"
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr "リモート %s に対するクラスター証明書の更新に成功しました"
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr "サポートするモード: %s"
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr "サポートするポート: %s"
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr "TARGET"
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr "--instance-only と --target は同時に指定できません"
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr "--mode と --storage は同時に指定できません"
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr "--mode と --target は同時に指定できません"
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr "--mode と --target-project は同時に指定できません"
 
@@ -5681,15 +5666,15 @@ msgstr "--mode と --target-project は同時に指定できません"
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr "--show-log フラグは 'console' アウトプットタイプの時だけ使えます"
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr "--storage と --target は同時に指定できません"
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr "--target-project と --target は同時に指定できません"
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr "移動先の LXD サーバはクラスタに属していません"
 
@@ -5697,7 +5682,7 @@ msgstr "移動先の LXD サーバはクラスタに属していません"
 msgid "The device already exists"
 msgstr "デバイスはすでに存在します"
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr "direction 引数は次のいずれかでなければなりません: ingress, egress"
 
@@ -5705,7 +5690,7 @@ msgstr "direction 引数は次のいずれかでなければなりません: ing
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr "インスタンスは実行中です。先に停止させるか、--force を指定してください"
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5713,11 +5698,11 @@ msgstr ""
 "インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
 "ださい"
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -5739,34 +5724,34 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "プロファイルのデバイスが存在しません"
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr "LXD サーバはすでにクラスターに属しています"
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
@@ -5791,25 +5776,25 @@ msgstr ""
 "仮想マシン上にローカルな LXD サーバを簡単にセットアップするには、https://"
 "multipass.run の使用を検討してください。"
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr "スレッド:"
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "インスタンスがクリーンにシャットダウンするまで待つ時間"
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 "インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
 "い"
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
@@ -5828,71 +5813,71 @@ msgstr ""
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
 "りません"
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr "合計: %v"
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr "転送モード。pull, push, relay のいずれか"
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr "転送モード。pull, push, relay のいずれか。"
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr "タイプ"
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr "証明書の形式"
 
@@ -5904,69 +5889,69 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: %s (ephemeral)"
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr "USAGE"
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr "USED BY"
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr "UUID"
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr "UUID: %v"
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr "リモートサーバーが利用できません"
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -5976,12 +5961,12 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr "未知の設定: %s"
@@ -5991,11 +5976,11 @@ msgstr "未知の設定: %s"
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
 
@@ -6003,7 +5988,7 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
@@ -6011,101 +5996,101 @@ msgstr "イメージのプロパティを削除します"
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr "ネットワーク ACL の設定を削除します"
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr "ネットワークゾーンの設定を削除します"
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を削除します"
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr "ストレージバケットの設定を削除します"
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr "Up delay"
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr "クラスター証明書を更新します"
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 "入力ファイルから読み込んだ PEM 証明書と鍵でクラスター証明書を更新します。"
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6116,7 +6101,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr "使用済: %v"
@@ -6125,54 +6110,54 @@ msgstr "使用済: %v"
 msgid "User ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 "ユーザからのシグナルを 3 度受信したので exit しました。リモート操作は実行し続"
 "けます"
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr "VFs: %d"
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr "VLAN ID"
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr "VLAN フィルタリング"
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr "VLAN:"
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr "ベンダー: %v"
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr "ベンダ: %v (%v)"
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr "Volume Only"
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr "WWN: %s"
@@ -6181,7 +6166,7 @@ msgstr "WWN: %s"
 msgid "Wait for the operation to complete"
 msgstr "処理が完全に終わるまで待ちます"
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "スナップショットを含めずにインスタンスのみをバックアップするかどうか"
 
@@ -6197,9 +6182,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "インスタンスの稼動状態のスナップショットを取得するかどうか"
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr "YES"
 
@@ -6211,77 +6196,77 @@ msgstr "-t と -T は同時に指定できません"
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "--mode と同時に -t または -T は指定できません"
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "[<remote>:] <backup file> [<instance name>]"
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "[<remote>:] <cert.crt> <cert.key>"
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr "[<remote>:] [<cert>]"
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filters>...]"
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr "[<remote>:]<ACL>"
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <direction> <key>=<value>..."
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr "[<remote>:]<ACL> <key>"
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <key>=<value>..."
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "[<remote>:]<ACL> <new-name>"
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "[<remote>:]<ACL> [key=value...]"
 
@@ -6289,81 +6274,81 @@ msgstr "[<remote>:]<ACL> [key=value...]"
 msgid "[<remote>:]<API path>"
 msgstr "[<remote>:]<API path>"
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr "[<remote>:]<Zone>"
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr "[<remote>:]<Zone> <key>"
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "[<remote>:]<Zone> <key>=<value>..."
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "[<remote>:]<Zone> [key=value...]"
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr "[<remote>:]<alias>"
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "[<remote>:]<alias> <fingerprint>"
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr "[<remote>:]<cluster member>"
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<fingerprint>"
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<group>"
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr "[<remote>:]<image> <remote>:"
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "[<remote>:]<image> [<remote>:][<name>]"
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr "[<remote>:]<instance>"
 
@@ -6387,11 +6372,11 @@ msgstr "[<remote>:]<instance> <device> [key=value...]"
 msgid "[<remote>:]<instance> <name>..."
 msgstr "[<remote>:]<instance> <name>..."
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr "[<remote>:]<instance> <profile>"
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "[<remote>:]<instance> <profiles>"
 
@@ -6399,8 +6384,8 @@ msgstr "[<remote>:]<instance> <profiles>"
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr "[<remote>:]<instance> <snapshot>"
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr "[<remote>:]<instance> <template>"
 
@@ -6408,7 +6393,7 @@ msgstr "[<remote>:]<instance> <template>"
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "[<remote>:]<instance> [<snapshot name>]"
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "[<remote>:]<instance> [[<remote>:]<instance>...]"
 
@@ -6416,25 +6401,25 @@ msgstr "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -6442,11 +6427,11 @@ msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
@@ -6457,24 +6442,24 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr "[<remote>:]<member> <key>"
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "[<remote>:]<member> <key>=<value>..."
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr "[<remote>:]<member> <new-name>"
 
@@ -6482,39 +6467,39 @@ msgstr "[<remote>:]<member> <new-name>"
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "[<remote>:]<member> <role[,role...]>"
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr "[<remote>:]<network>"
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>]"
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr "[<remote>:]<network> <key>"
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "[<remote>:]<network> <listen_address>"
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "[<remote>:]<network> <listen_address> <backend_name>"
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
@@ -6522,16 +6507,16 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "[<remote>:]<network> <listen_address> <key>"
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "[<remote>:]<network> <listen_address> <key>=<value>..."
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
@@ -6539,7 +6524,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
@@ -6547,27 +6532,27 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "[<remote>:]<network> <listen_address> [key=value...]"
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr "[<remote>:]<network> <new-name>"
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr "[<remote>:]<network> <peer name>"
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "[<remote>:]<network> <peer_name>"
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
@@ -6575,71 +6560,71 @@ msgstr ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "[<remote>:]<network> <peer_name> <key>"
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "[<remote>:]<network> <peer_name> <key>=<value>..."
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>]"
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "[<remote>:]<network> [key=value...]"
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr "[<remote>:]<operation>"
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "[<remote>:]<pool> <bucket>"
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "[<remote>:]<pool> <bucket> <key>"
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "[<remote>:]<pool> <bucket> <key>=<value>..."
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "[<remote>:]<pool> <bucket> [key=value...]"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "[<remote>:]<pool> <driver> [key=value...]"
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr "[<remote>:]<pool> <key>"
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6647,65 +6632,65 @@ msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr "[<remote>:]<pool> <volume> <key>"
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr "[<remote>:]<profile>"
 
@@ -6721,11 +6706,11 @@ msgstr "[<remote>:]<profile> <device> <key>=<value>..."
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "[<remote>:]<profile> <device> <type> [key=value...]"
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr "[<remote>:]<profile> <key>"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "[<remote>:]<profile> <key><value>..."
 
@@ -6733,60 +6718,60 @@ msgstr "[<remote>:]<profile> <key><value>..."
 msgid "[<remote>:]<profile> <name>..."
 msgstr "[<remote>:]<profile> <name>..."
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "[<remote>:]<profile> <new-name>"
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr "[<remote>:]<project>"
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr "[<remote>:]<project> <key>"
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "[<remote>:]<project> <key>=<value>..."
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr "[<remote>:]<project> <new-name>"
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr "[<remote>:]<warning-uuid>"
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr "[<remote>:]<zone>"
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr "[<remote>:]<zone> <record>"
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "[<remote>:]<zone> <record> <key>"
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "[<remote>:]<zone> <record> <key>=<value>..."
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "[<remote>:]<zone> <record> <type> <value>"
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 
@@ -6794,7 +6779,7 @@ msgstr "[<remote>:]<zone> <record> [key=value...]"
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "[<remote>:][<instance>[/<snapshot>]]"
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr "[<remote>:][<instance>]"
 
@@ -6806,45 +6791,45 @@ msgstr "[<remote>:][<instance>] <key>"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "[<remote>] <IP|FQDN|URL|token>"
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 #, fuzzy
 msgid "[[<remote>:]<name>]"
 msgstr "[<remote>:] <name>"
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr "現在値"
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr "説明"
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr "無効"
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr "ドライバ"
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr "有効"
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr "エラー: %v"
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr "ストレージ情報"
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
@@ -6852,7 +6837,7 @@ msgstr ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    \"list\" コマンドを \"list -c ns46S\" で上書きします。"
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
@@ -6860,7 +6845,7 @@ msgstr ""
 "lxc alias remove my-list\n"
 "     \"my-list\" というエイリアスを削除します。"
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6868,7 +6853,7 @@ msgstr ""
 "lxc alias rename list my-list\n"
 "    エイリアス名 \"list\" を \"my-list\" に変更します。"
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6876,7 +6861,7 @@ msgstr ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    member.yaml の内容でクラスターメンバーを更新します"
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6937,7 +6922,7 @@ msgstr ""
 "lxc config set core.trust_password=blah\n"
 "    サーバの認証パスワードを blah に設定します。"
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -6945,7 +6930,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -6954,7 +6939,7 @@ msgstr ""
 "   インスタンス foo の /root をローカルの fooroot ディレクトリにマウントしま"
 "す。"
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
@@ -6964,7 +6949,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6973,7 +6958,7 @@ msgstr ""
 "   /etc/hosts ファイルを、インスタンス \"foo\" 内 (の /etc/hosts) にコピーし"
 "ます。"
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6987,7 +6972,7 @@ msgstr ""
 "lxc image edit <image> < image.yaml\n"
 "    YAML ファイルからイメージプロパティをロードします"
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
@@ -6995,7 +6980,7 @@ msgstr ""
 "lxc import backup0.tar.gz\n"
 "    backup0.tar.gz を使って新しいインスタンスを作成します。"
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7009,7 +6994,7 @@ msgstr ""
 "lxc info [<remote>:] [--resources]\n"
 "    LXD サーバの情報を表示します。"
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -7021,7 +7006,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 #, fuzzy
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
@@ -7044,7 +7029,7 @@ msgstr ""
 "lxc launch ubuntu:22.04 v1 --vm\n"
 "    仮想マシンを作成し、起動します"
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7088,7 +7073,7 @@ msgstr ""
 "lxc monitor --type=lifecycle\n"
 "    lifecycle イベントのみを表示します。"
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7113,7 +7098,7 @@ msgstr ""
 "lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    スナップショットをリネームします。"
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7122,7 +7107,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7130,7 +7115,7 @@ msgstr ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    上記のオペレーション UUID の詳細を表示します"
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7170,7 +7155,7 @@ msgstr ""
 "    some-pool 上の some-volume ボリュームをインスタンスの /opt にマウントしま"
 "す。"
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -7178,7 +7163,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7216,7 +7201,7 @@ msgstr ""
 "lxc restore u1 snap0\n"
 "    スナップショットからリストアします。"
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
@@ -7224,7 +7209,7 @@ msgstr ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    bucket.yaml の内容でストレージバケットを更新します。"
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
@@ -7232,7 +7217,7 @@ msgstr ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    key.yaml の内容でストレージバケットの鍵を更新します。"
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
@@ -7242,7 +7227,7 @@ msgstr ""
 "    \"default\" プール内の \"data\" という名前のバケットに対する \"foo\" とい"
 "う名前のバケットの鍵のプロパティを表示します。"
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7251,7 +7236,7 @@ msgstr ""
 "lxc storage bucket show default data\n"
 "    \"default\" プール内の \"data\" というバケットのプロパティを表示します。"
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -7259,7 +7244,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
@@ -7267,7 +7252,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7275,15 +7260,15 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 "lxc storage volume show default data\n"
 "    \"default\" プール内のカスタムボリューム \"data\" のプロパティを表示しま"
@@ -7293,19 +7278,19 @@ msgstr ""
 "    \"default\" プール内のコンテナ \"data\" のファイルシステムプロパティを表"
 "示します。"
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr "n"
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr "名前"
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -7313,26 +7298,26 @@ msgstr "ok (y/n/[fingerprint])?"
 msgid "please use `lxc profile`"
 msgstr "`lxc profile` コマンドを使ってください"
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"
 "てください"
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr "総容量"
 
@@ -7340,18 +7325,30 @@ msgstr "総容量"
 msgid "unreachable"
 msgstr "サーバに接続できません"
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr "yes"
+
+#, c-format
+#~ msgid "%v (interrupt two more times to force)"
+#~ msgstr ""
+#~ "%v (強制的に中断したい場合はあと2回Ctrl-Cを入力/SIGINTを送出してください)"
+
+#, c-format
+#~ msgid "Invalid format %q"
+#~ msgstr "不正なフォーマット %q"
+
+#~ msgid "Remote operation canceled by user"
+#~ msgstr "リモート操作がユーザによってキャンセルされました"
 
 #~ msgid "[[<remote>:]<member>]"
 #~ msgstr "[[<remote>:]<member>]"
@@ -8997,8 +8994,8 @@ msgstr "yes"
 #~ "lxc storage volume move [<pool>/]<volume> [<pool>/]<volume>\n"
 #~ "    Move an existing volume to the specified pool.\n"
 #~ "\n"
-#~ "Unless specified through a prefix, all volume operations affect \"custom"
-#~ "\" (user created) volumes.\n"
+#~ "Unless specified through a prefix, all volume operations affect "
+#~ "\"custom\" (user created) volumes.\n"
 #~ "\n"
 #~ "*Examples*\n"
 #~ "cat pool.yaml | lxc storage edit [<remote>:]<pool>\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2023-06-02 17:14+0200\n"
+        "POT-Creation-Date: 2023-06-08 15:47+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr  "Project-Id-Version: lxd\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid   "### This is a YAML representation of a storage bucket.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -28,7 +28,7 @@ msgid   "### This is a YAML representation of a storage bucket.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid   "### This is a YAML representation of a storage pool.\n"
         "### Any line starting with a '#' will be ignored.\n"
         "###\n"
@@ -44,7 +44,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -57,14 +57,14 @@ msgid   "### This is a YAML representation of a storage volume.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid   "### This is a YAML representation of the certificate.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
         "### Note that the fingerprint is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid   "### This is a YAML representation of the cluster group.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
@@ -89,7 +89,7 @@ msgid   "### This is a YAML representation of the configuration.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid   "### This is a YAML representation of the image properties.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -121,7 +121,7 @@ msgid   "### This is a YAML representation of the instance metadata.\n"
         "###     properties: {}"
 msgstr  ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid   "### This is a YAML representation of the network ACL.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -147,7 +147,7 @@ msgid   "### This is a YAML representation of the network ACL.\n"
         "### Note that only the ingress and egress rules, description and configuration keys can be changed."
 msgstr  ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid   "### This is a YAML representation of the network forward.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -169,7 +169,7 @@ msgid   "### This is a YAML representation of the network forward.\n"
         "### Note that the listen_address and location cannot be changed."
 msgstr  ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid   "### This is a YAML representation of the network load balancer.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -191,7 +191,7 @@ msgid   "### This is a YAML representation of the network load balancer.\n"
         "### Note that the listen_address and location cannot be changed."
 msgstr  ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid   "### This is a YAML representation of the network peer.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -206,7 +206,7 @@ msgid   "### This is a YAML representation of the network peer.\n"
         "### Note that the name, target_project, target_network and status fields cannot be changed."
 msgstr  ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid   "### This is a YAML representation of the network zone record.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -219,7 +219,7 @@ msgid   "### This is a YAML representation of the network zone record.\n"
         "###  user.foo: bah\n"
 msgstr  ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid   "### This is a YAML representation of the network zone.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -232,7 +232,7 @@ msgid   "### This is a YAML representation of the network zone.\n"
         "###  user.foo: bah\n"
 msgstr  ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid   "### This is a YAML representation of the network.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -251,7 +251,7 @@ msgid   "### This is a YAML representation of the network.\n"
         "### Note that only the configuration can be changed."
 msgstr  ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid   "### This is a YAML representation of the profile.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -271,7 +271,7 @@ msgid   "### This is a YAML representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid   "### This is a YAML representation of the project.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -291,73 +291,68 @@ msgid   "### This is a YAML representation of the project.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid   "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr  ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid   "%s (%d available)"
 msgstr  ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid   "%v (interrupt two more times to force)"
-msgstr  ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid   "(none)"
 msgstr  ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid   "- Level %d (type: %s): %s"
 msgstr  ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid   "- Partition %d"
 msgstr  ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid   "- Port %d (%s)"
 msgstr  ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid   "--console can't be used while forcing instance shutdown"
 msgstr  ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid   "--console can't be used with --all"
 msgstr  ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid   "--console only works with a single instance"
 msgstr  ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
@@ -365,11 +360,11 @@ msgstr  ""
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid   "--instance-only can't be passed when the source is a snapshot"
 msgstr  ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid   "--no-profiles cannot be used with --refresh"
 msgstr  ""
 
@@ -377,43 +372,43 @@ msgstr  ""
 msgid   "--project cannot be used with the query command"
 msgstr  ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688 lxc/info.go:452
+#: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688 lxc/info.go:451
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid   "<alias>"
 msgstr  ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid   "<alias> <target>"
 msgstr  ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid   "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr  ""
 
@@ -421,31 +416,31 @@ msgstr  ""
 msgid   "<target>"
 msgstr  ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid   "ALIAS"
 msgstr  ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid   "AUTH TYPE"
 msgstr  ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid   "Accept certificate"
 msgstr  ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid   "Access key (auto-generated if empty)"
 msgstr  ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid   "Access key: %s"
 msgstr  ""
@@ -454,7 +449,7 @@ msgstr  ""
 msgid   "Access the expanded configuration"
 msgstr  ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid   "Acknowledge warning"
 msgstr  ""
 
@@ -467,19 +462,19 @@ msgstr  ""
 msgid   "Action (defaults to GET)"
 msgstr  ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid   "Add a network zone record entry"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid   "Add backend to a load balancer"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid   "Add backends to a load balancer"
 msgstr  ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid   "Add entries to a network zone record"
 msgstr  ""
 
@@ -487,15 +482,15 @@ msgstr  ""
 msgid   "Add instance devices"
 msgstr  ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid   "Add new aliases"
 msgstr  ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid   "Add new remote servers"
 msgstr  ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid   "Add new remote servers\n"
         "\n"
         "URL for remote resources must be HTTPS (https://).\n"
@@ -504,11 +499,11 @@ msgid   "Add new remote servers\n"
         "  lxc remote add some-name https://LOGIN:PASSWORD@example.com/some/path --protocol=simplestreams\n"
 msgstr  ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid   "Add new trusted client"
 msgstr  ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid   "Add new trusted client\n"
         "\n"
         "The following certificate types are supported:\n"
@@ -521,15 +516,15 @@ msgid   "Add new trusted client\n"
         "restricted to one or more projects.\n"
 msgstr  ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid   "Add ports to a forward"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid   "Add ports to a load balancer"
 msgstr  ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid   "Add profiles to instances"
 msgstr  ""
 
@@ -537,76 +532,76 @@ msgstr  ""
 msgid   "Add roles to a cluster member"
 msgstr  ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid   "Add rules to an ACL"
 msgstr  ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid   "Address: %s"
 msgstr  ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid   "Admin secret key: %s"
 msgstr  ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid   "Alias %s already exists"
 msgstr  ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid   "Alias %s doesn't exist"
 msgstr  ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid   "Alias name missing"
 msgstr  ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid   "Aliases already exists: %s"
 msgstr  ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid   "All projects"
 msgstr  ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid   "All server addresses are unavailable"
 msgstr  ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid   "Architecture: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
@@ -615,35 +610,35 @@ msgstr  ""
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid   "Assign sets of groups to cluster members"
 msgstr  ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid   "Assign sets of profiles to instances"
 msgstr  ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid   "Attach network interfaces to instances"
 msgstr  ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid   "Attach network interfaces to profiles"
 msgstr  ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid   "Attach new network interfaces to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid   "Attach new storage volumes to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid   "Attach new storage volumes to profiles"
 msgstr  ""
 
@@ -658,48 +653,48 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid   "Auto negotiation: %v"
 msgstr  ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid   "Auto update is only available in pull mode"
 msgstr  ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid   "Auto update: %s"
 msgstr  ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid   "Available projects:"
 msgstr  ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid   "BASE IMAGE"
 msgstr  ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid   "Backups:"
 msgstr  ""
 
@@ -708,115 +703,115 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285 lxc/network_load_balancer.go:287 lxc/network_peer.go:281 lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284 lxc/network_load_balancer.go:286 lxc/network_peer.go:280 lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180 lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179 lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid   "Bad property: %s"
 msgstr  ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid   "Bond:"
 msgstr  ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid   "Both --all and instance name given"
 msgstr  ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid   "Brand: %v"
 msgstr  ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid   "Bridge:"
 msgstr  ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid   "Bytes received"
 msgstr  ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid   "Bytes sent"
 msgstr  ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid   "CANCELABLE"
 msgstr  ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid   "COUNT"
 msgstr  ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid   "CPU (%s):"
 msgstr  ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid   "CPU USAGE"
 msgstr  ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid   "CPU usage:"
 msgstr  ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid   "CPUs (%s):"
 msgstr  ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid   "CREATED"
 msgstr  ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid   "CREATED AT"
 msgstr  ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid   "CUDA Version: %v"
 msgstr  ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid   "Cached: %s"
 msgstr  ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid   "Caches:"
 msgstr  ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -825,15 +820,15 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid   "Can't remove the default remote"
 msgstr  ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid   "Can't specify --fast with --columns"
 msgstr  ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid   "Can't specify --project with --all-projects"
 msgstr  ""
 
@@ -841,11 +836,11 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -854,67 +849,67 @@ msgstr  ""
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid   "Candid domain to use"
 msgstr  ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid   "Cannot override config for device %q: Device not found in profile devices"
 msgstr  ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid   "Cannot set --destination-target when destination server is not clustered"
 msgstr  ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid   "Cannot set --target when source server is not clustered"
 msgstr  ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid   "Cannot set key: %s"
 msgstr  ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid   "Cannot use metrics type certificate when using a token"
 msgstr  ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid   "Card %d:"
 msgstr  ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid   "Card: %s (%s)"
 msgstr  ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid   "Certificate add token for %s deleted"
 msgstr  ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid   "Chassis"
 msgstr  ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -923,58 +918,58 @@ msgstr  ""
 msgid   "Client version: %s\n"
 msgstr  ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid   "Cluster group %s created"
 msgstr  ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid   "Cluster group %s deleted"
 msgstr  ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid   "Cluster group %s isn't currently applied to %s"
 msgstr  ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid   "Cluster group %s renamed to %s"
 msgstr  ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid   "Cluster join token for %s:%s deleted"
 msgstr  ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid   "Cluster member %s added to cluster groups %s"
 msgstr  ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630 lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56 lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776 lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245 lxc/network_forward.go:171 lxc/network_forward.go:235 lxc/network_forward.go:390 lxc/network_forward.go:491 lxc/network_forward.go:633 lxc/network_forward.go:710 lxc/network_forward.go:776 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636 lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776 lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939 lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658 lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86 lxc/storage_bucket.go:186 lxc/storage_bucket.go:249 lxc/storage_bucket.go:378 lxc/storage_bucket.go:523 lxc/storage_bucket.go:599 lxc/storage_bucket.go:663 lxc/storage_bucket.go:814 lxc/storage_bucket.go:892 lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093 lxc/storage_volume.go:334 lxc/storage_volume.go:532 lxc/storage_volume.go:611 lxc/storage_volume.go:852 lxc/storage_volume.go:1053 lxc/storage_volume.go:1141 lxc/storage_volume.go:1572 lxc/storage_volume.go:1604 lxc/storage_volume.go:1720 lxc/storage_volume.go:1811 lxc/storage_volume.go:1904 lxc/storage_volume.go:1941 lxc/storage_volume.go:2034 lxc/storage_volume.go:2106 lxc/storage_volume.go:2248
+#: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630 lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55 lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775 lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:632 lxc/network_forward.go:709 lxc/network_forward.go:775 lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391 lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635 lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775 lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938 lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657 lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85 lxc/storage_bucket.go:185 lxc/storage_bucket.go:248 lxc/storage_bucket.go:377 lxc/storage_bucket.go:522 lxc/storage_bucket.go:598 lxc/storage_bucket.go:662 lxc/storage_bucket.go:813 lxc/storage_bucket.go:891 lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092 lxc/storage_volume.go:333 lxc/storage_volume.go:531 lxc/storage_volume.go:610 lxc/storage_volume.go:851 lxc/storage_volume.go:1052 lxc/storage_volume.go:1140 lxc/storage_volume.go:1571 lxc/storage_volume.go:1603 lxc/storage_volume.go:1719 lxc/storage_volume.go:1810 lxc/storage_volume.go:1903 lxc/storage_volume.go:1940 lxc/storage_volume.go:2033 lxc/storage_volume.go:2105 lxc/storage_volume.go:2247
 msgid   "Cluster member name"
 msgstr  ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid   "Cluster member name (alternative to passing it as an argument)"
 msgstr  ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid   "Cluster member name was provided as both a flag and as an argument"
 msgstr  ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360 lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359 lxc/warning.go:92
 msgid   "Columns"
 msgstr  ""
 
@@ -989,27 +984,27 @@ msgid   "Command line client for LXD\n"
         "For help with any of those, simply call them with --help."
 msgstr  ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid   "Compression algorithm to use (`none` for uncompressed)"
 msgstr  ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid   "Compression algorithm to use (none for uncompressed)"
 msgstr  ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid   "Config key/value to apply to the new instance"
 msgstr  ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263 lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582 lxc/network_forward.go:597 lxc/network_load_balancer.go:600 lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056 lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263 lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581 lxc/network_forward.go:596 lxc/network_load_balancer.go:599 lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066 lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055 lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1018,44 +1013,44 @@ msgstr  ""
 msgid   "Console log:"
 msgstr  ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid   "Control: %s (%s)"
 msgstr  ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid   "Copy a stateful instance stateless"
 msgstr  ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid   "Copy aliases from source"
 msgstr  ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid   "Copy images between servers"
 msgstr  ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid   "Copy images between servers\n"
         "\n"
         "The auto-update flag instructs the server to keep this image up to date.\n"
         "It requires the source to be an alias and for it to be public."
 msgstr  ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid   "Copy instances within or in between LXD servers"
 msgstr  ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid   "Copy instances within or in between LXD servers\n"
         "\n"
         "Transfer modes (--mode):\n"
@@ -1070,113 +1065,113 @@ msgstr  ""
 msgid   "Copy profile inherited devices and override configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid   "Copy profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid   "Copy storage volumes"
 msgstr  ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid   "Copy the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251 lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250 lxc/storage_volume.go:336
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid   "Copy virtual machine images"
 msgstr  ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid   "Copying the storage volume: %s"
 msgstr  ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid   "Core %d"
 msgstr  ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid   "Could not create server cert dir"
 msgstr  ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid   "Could not find certificate file path: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid   "Could not read certificate file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid   "Could not read certificate key file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid   "Couldn't find a matching entry"
 msgstr  ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid   "Create a cluster group"
 msgstr  ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid   "Create a virtual machine"
 msgstr  ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid   "Create aliases for existing images"
 msgstr  ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid   "Create an empty instance"
 msgstr  ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid   "Create any directories necessary"
 msgstr  ""
 
@@ -1191,142 +1186,142 @@ msgid   "Create instance snapshots\n"
         "running state, including process memory state, TCP connections, ..."
 msgstr  ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid   "Create instances from images"
 msgstr  ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid   "Create key for a storage bucket"
 msgstr  ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid   "Create new instance file templates"
 msgstr  ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid   "Create new network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid   "Create new network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid   "Create new network load balancers"
 msgstr  ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid   "Create new network peering"
 msgstr  ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid   "Create new network zone record"
 msgstr  ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid   "Create new network zones"
 msgstr  ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid   "Create new networks"
 msgstr  ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid   "Create profiles"
 msgstr  ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid   "Create projects"
 msgstr  ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid   "Create storage pools"
 msgstr  ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid   "Creating the instance"
 msgstr  ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid   "Current number of VFs: %d"
 msgstr  ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059 lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969 lxc/network_acl.go:149 lxc/network_forward.go:146 lxc/network_load_balancer.go:149 lxc/network_peer.go:141 lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164 lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635 lxc/storage_bucket.go:496 lxc/storage_bucket.go:791 lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968 lxc/network_acl.go:148 lxc/network_forward.go:145 lxc/network_load_balancer.go:148 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163 lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634 lxc/storage_bucket.go:495 lxc/storage_bucket.go:790 lxc/storage_volume.go:1466
 msgid   "DESCRIPTION"
 msgstr  ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid   "DISK USAGE"
 msgstr  ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid   "DRIVER"
 msgstr  ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid   "DRM:"
 msgstr  ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid   "Delete a background operation (will attempt to cancel)"
 msgstr  ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid   "Delete a cluster group"
 msgstr  ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid   "Delete files in instances"
 msgstr  ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid   "Delete image aliases"
 msgstr  ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid   "Delete images"
 msgstr  ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid   "Delete instance file templates"
 msgstr  ""
 
@@ -1334,88 +1329,88 @@ msgstr  ""
 msgid   "Delete instances and snapshots"
 msgstr  ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid   "Delete key from a storage bucket"
 msgstr  ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid   "Delete network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid   "Delete network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid   "Delete network load balancers"
 msgstr  ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid   "Delete network peerings"
 msgstr  ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid   "Delete network zone record"
 msgstr  ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid   "Delete network zones"
 msgstr  ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid   "Delete networks"
 msgstr  ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid   "Delete profiles"
 msgstr  ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid   "Delete projects"
 msgstr  ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid   "Delete storage buckets"
 msgstr  ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148 lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207 lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404 lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651 lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023 lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626 lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351 lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581 lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504 lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896 lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110 lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:168 lxc/network_forward.go:232 lxc/network_forward.go:328 lxc/network_forward.go:383 lxc/network_forward.go:461 lxc/network_forward.go:488 lxc/network_forward.go:630 lxc/network_forward.go:692 lxc/network_forward.go:707 lxc/network_forward.go:772 lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398 lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655 lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665 lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726 lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245 lxc/storage_bucket.go:376 lxc/storage_bucket.go:442 lxc/storage_bucket.go:517 lxc/storage_bucket.go:594 lxc/storage_bucket.go:661 lxc/storage_bucket.go:692 lxc/storage_bucket.go:733 lxc/storage_bucket.go:811 lxc/storage_bucket.go:889 lxc/storage_bucket.go:953 lxc/storage_bucket.go:1088 lxc/storage_volume.go:42 lxc/storage_volume.go:164 lxc/storage_volume.go:239 lxc/storage_volume.go:330 lxc/storage_volume.go:529 lxc/storage_volume.go:608 lxc/storage_volume.go:683 lxc/storage_volume.go:765 lxc/storage_volume.go:846 lxc/storage_volume.go:1050 lxc/storage_volume.go:1138 lxc/storage_volume.go:1278 lxc/storage_volume.go:1362 lxc/storage_volume.go:1568 lxc/storage_volume.go:1601 lxc/storage_volume.go:1714 lxc/storage_volume.go:1802 lxc/storage_volume.go:1901 lxc/storage_volume.go:1935 lxc/storage_volume.go:2032 lxc/storage_volume.go:2099 lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403 lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650 lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022 lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29 lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204 lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439 lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626 lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216 lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503 lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895 lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109 lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396 lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614 lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727 lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:629 lxc/network_forward.go:691 lxc/network_forward.go:706 lxc/network_forward.go:771 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384 lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:934 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453 lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770 lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954 lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148 lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23 lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184 lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248 lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539 lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775 lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397 lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654 lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342 lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725 lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:375 lxc/storage_bucket.go:441 lxc/storage_bucket.go:516 lxc/storage_bucket.go:593 lxc/storage_bucket.go:660 lxc/storage_bucket.go:691 lxc/storage_bucket.go:732 lxc/storage_bucket.go:810 lxc/storage_bucket.go:888 lxc/storage_bucket.go:952 lxc/storage_bucket.go:1087 lxc/storage_volume.go:41 lxc/storage_volume.go:163 lxc/storage_volume.go:238 lxc/storage_volume.go:329 lxc/storage_volume.go:528 lxc/storage_volume.go:607 lxc/storage_volume.go:682 lxc/storage_volume.go:764 lxc/storage_volume.go:845 lxc/storage_volume.go:1049 lxc/storage_volume.go:1137 lxc/storage_volume.go:1277 lxc/storage_volume.go:1361 lxc/storage_volume.go:1567 lxc/storage_volume.go:1600 lxc/storage_volume.go:1713 lxc/storage_volume.go:1801 lxc/storage_volume.go:1900 lxc/storage_volume.go:1934 lxc/storage_volume.go:2031 lxc/storage_volume.go:2098 lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid   "Destination cluster member name"
 msgstr  ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid   "Detach network interfaces from instances"
 msgstr  ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid   "Detach storage volumes from instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
@@ -1455,16 +1450,16 @@ msgstr  ""
 msgid   "Device from profile(s) cannot be retrieved for individual instance"
 msgstr  ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid   "Device: %s"
 msgstr  ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid   "Directory import is not available on this platform"
 msgstr  ""
 
@@ -1472,7 +1467,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1484,28 +1479,28 @@ msgstr  ""
 msgid   "Disable stdin (reads from /dev/null)"
 msgstr  ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid   "Disk %d:"
 msgstr  ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid   "Disk usage:"
 msgstr  ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid   "Disk:"
 msgstr  ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid   "Disks:"
 msgstr  ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid   "Display instances from all projects"
 msgstr  ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
@@ -1513,52 +1508,52 @@ msgstr  ""
 msgid   "Don't show progress information"
 msgstr  ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid   "Down delay"
 msgstr  ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid   "Driver: %v (%v)"
 msgstr  ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid   "ENTRIES"
 msgstr  ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid   "EPHEMERAL"
 msgstr  ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid   "EXPIRES AT"
 msgstr  ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid   "Edit a cluster group"
 msgstr  ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid   "Edit files in instances"
 msgstr  ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid   "Edit image properties"
 msgstr  ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid   "Edit instance file templates"
 msgstr  ""
 
@@ -1570,72 +1565,72 @@ msgstr  ""
 msgid   "Edit instance or server configurations as YAML"
 msgstr  ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid   "Edit network ACL configurations as YAML"
 msgstr  ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid   "Edit network configurations as YAML"
 msgstr  ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid   "Edit network forward configurations as YAML"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid   "Edit network load balancer configurations as YAML"
 msgstr  ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid   "Edit network peer configurations as YAML"
 msgstr  ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid   "Edit network zone configurations as YAML"
 msgstr  ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid   "Edit network zone record configurations as YAML"
 msgstr  ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid   "Edit project configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid   "Edit storage bucket configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid   "Edit storage bucket key as YAML"
 msgstr  ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495 lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494 lxc/warning.go:235
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid   "Enable clustering on a single non-clustered LXD server"
 msgstr  ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid   "Enable clustering on a single non-clustered LXD server\n"
         "\n"
         "  This command turns a non-clustered LXD server into the first member of a new\n"
@@ -1646,7 +1641,7 @@ msgid   "Enable clustering on a single non-clustered LXD server\n"
         "  for the address if not yet set."
 msgstr  ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid   "Entry TTL"
 msgstr  ""
 
@@ -1654,25 +1649,25 @@ msgstr  ""
 msgid   "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr  ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid   "Ephemeral instance"
 msgstr  ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid   "Error updating template file: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid   "Evacuate cluster member"
 msgstr  ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid   "Evacuating cluster member: %s"
 msgstr  ""
@@ -1698,77 +1693,77 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279 lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278 lxc/storage_volume.go:1328
 msgid   "Expires at"
 msgstr  ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid   "Expires: %s"
 msgstr  ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid   "Expires: never"
 msgstr  ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid   "Export and download images"
 msgstr  ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid   "Export and download images\n"
         "\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid   "Export custom storage volume"
 msgstr  ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid   "Export instance backups"
 msgstr  ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid   "Exporting the image: %s"
 msgstr  ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid   "FAILURE DOMAIN"
 msgstr  ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid   "FILENAME"
 msgstr  ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057 lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056 lxc/image_alias.go:235
 msgid   "FINGERPRINT"
 msgstr  ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -1783,37 +1778,37 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid   "Failed converting token operation to certificate add token: %w"
 msgstr  ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid   "Failed getting peer's status: %w"
 msgstr  ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid   "Failed loading profile %q for device override: %w"
 msgstr  ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -1823,31 +1818,31 @@ msgstr  ""
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid   "Failed to add remote"
 msgstr  ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid   "Failed to create %q: %w"
 msgstr  ""
@@ -1857,26 +1852,26 @@ msgstr  ""
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid   "Failed to create certificate: %w"
 msgstr  ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid   "Failed to get the new instance name"
 msgstr  ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid   "Failed to refresh target instance '%s': %v"
 msgstr  ""
@@ -1886,34 +1881,34 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid   "Failed to write server cert file %q: %w"
 msgstr  ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116 lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115 lxc/operation.go:133
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid   "Fingerprint: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid   "Force a particular evacuation action"
 msgstr  ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid   "Force evacuation without user confirmation"
 msgstr  ""
 
@@ -1921,11 +1916,11 @@ msgstr  ""
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid   "Force the instance to stop"
 msgstr  ""
 
@@ -1937,7 +1932,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid   "Forcefully removing a server from the cluster should only be done as a last\n"
         "resort.\n"
@@ -1956,7 +1951,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843 lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353 lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98 lxc/network_forward.go:90 lxc/network_load_balancer.go:94 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654 lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400 lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577 lxc/storage_bucket.go:443 lxc/storage_bucket.go:734 lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842 lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653 lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399 lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576 lxc/storage_bucket.go:442 lxc/storage_bucket.go:733 lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -1968,7 +1963,7 @@ msgstr  ""
 msgid   "Format (man|md|rest|yaml)"
 msgstr  ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid   "Forward delay"
 msgstr  ""
 
@@ -1977,30 +1972,30 @@ msgstr  ""
 msgid   "Found alias %q references an argument outside the given number"
 msgstr  ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid   "Free: %v"
 msgstr  ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid   "Frequency: %vMhz"
 msgstr  ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid   "GLOBAL"
 msgstr  ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid   "GPU:"
 msgstr  ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid   "GPUs:"
 msgstr  ""
 
@@ -2008,23 +2003,23 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid   "Get image properties"
 msgstr  ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid   "Get runtime information on networks"
 msgstr  ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid   "Get values for cluster member configuration keys"
 msgstr  ""
 
@@ -2036,55 +2031,55 @@ msgstr  ""
 msgid   "Get values for instance or server configuration keys"
 msgstr  ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid   "Get values for network ACL configuration keys"
 msgstr  ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid   "Get values for network configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid   "Get values for network forward configuration keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid   "Get values for network load balancer configuration keys"
 msgstr  ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid   "Get values for network peer configuration keys"
 msgstr  ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid   "Get values for network zone configuration keys"
 msgstr  ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid   "Get values for network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid   "Get values for project configuration keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid   "Get values for storage bucket configuration keys"
 msgstr  ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
@@ -2093,85 +2088,85 @@ msgstr  ""
 msgid   "Group ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid   "HOSTNAME"
 msgstr  ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid   "Host interface"
 msgstr  ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid   "ID"
 msgstr  ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid   "ID: %d"
 msgstr  ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid   "ID: %s"
 msgstr  ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid   "IMAGES"
 msgstr  ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid   "IP addresses"
 msgstr  ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid   "IP addresses:"
 msgstr  ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid   "IPV6"
 msgstr  ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -2183,93 +2178,93 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid   "Ignore copy errors for volatile files"
 msgstr  ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid   "Image already up to date."
 msgstr  ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid   "Image copied successfully!"
 msgstr  ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid   "Image expiration date (format: rfc3339)"
 msgstr  ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid   "Import custom storage volumes"
 msgstr  ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid   "Import image into the image store\n"
         "\n"
         "Directory import is only available on Linux and must be performed as root."
 msgstr  ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid   "Import images into the image store"
 msgstr  ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid   "Import instance backups"
 msgstr  ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid   "Importing instance: %s"
 msgstr  ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid   "Infiniband:"
 msgstr  ""
 
@@ -2277,42 +2272,42 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid   "Instance Only"
 msgstr  ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid   "Instance published with fingerprint: %s"
 msgstr  ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2322,23 +2317,18 @@ msgstr  ""
 msgid   "Invalid argument %q"
 msgstr  ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid   "Invalid certificate"
 msgstr  ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid   "Invalid config key '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid   "Invalid config key column format (too many fields): '%s'"
-msgstr  ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid   "Invalid format %q"
 msgstr  ""
 
 #: lxc/monitor.go:71
@@ -2351,7 +2341,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -2361,30 +2351,30 @@ msgstr  ""
 msgid   "Invalid key=value configuration: %s"
 msgstr  ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid   "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid   "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid   "Invalid new snapshot name"
 msgstr  ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid   "Invalid new snapshot name, parent must be the same as source"
 msgstr  ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
@@ -2392,56 +2382,56 @@ msgstr  ""
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086 lxc/storage_volume.go:1174 lxc/storage_volume.go:1637 lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085 lxc/storage_volume.go:1173 lxc/storage_volume.go:1636 lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid   "IsSM: %s (%s)"
 msgstr  ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid   "LAST SEEN"
 msgstr  ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid   "LIMIT"
 msgstr  ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152 lxc/network_load_balancer.go:154 lxc/operation.go:169 lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151 lxc/network_load_balancer.go:153 lxc/operation.go:168 lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid   "LOCATION"
 msgstr  ""
 
@@ -2453,121 +2443,121 @@ msgstr  ""
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062 lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061 lxc/cluster_group.go:403
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid   "Last Used: %s"
 msgstr  ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid   "Last used: %s"
 msgstr  ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid   "Last used: never"
 msgstr  ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid   "Link detected: %v"
 msgstr  ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid   "Link speed: %dMbit/s (%s duplex)"
 msgstr  ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid   "List DHCP leases"
 msgstr  ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid   "List aliases"
 msgstr  ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid   "List all active certificate add tokens"
 msgstr  ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid   "List all active cluster member join tokens"
 msgstr  ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid   "List all the cluster groups"
 msgstr  ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid   "List all the cluster members"
 msgstr  ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid   "List all warnings"
 msgstr  ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid   "List available network ACL"
 msgstr  ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid   "List available network ACLS"
 msgstr  ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid   "List available network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid   "List available network load balancers"
 msgstr  ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid   "List available network peers"
 msgstr  ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid   "List available network zone"
 msgstr  ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid   "List available network zone records"
 msgstr  ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid   "List available network zoneS"
 msgstr  ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid   "List available networks"
 msgstr  ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid   "List available storage pools"
 msgstr  ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid   "List background operations"
 msgstr  ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid   "List image aliases"
 msgstr  ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid   "List image aliases\n"
         "\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr  ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid   "List images"
 msgstr  ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid   "List images\n"
         "\n"
         "Filters may be of the <key>=<value> form for property based filtering,\n"
@@ -2597,15 +2587,15 @@ msgstr  ""
 msgid   "List instance devices"
 msgstr  ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid   "List instance file templates"
 msgstr  ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid   "List instances"
 msgstr  ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid   "List instances\n"
         "\n"
@@ -2680,31 +2670,31 @@ msgid   "List instances\n"
         "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr  ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid   "List of projects to restrict the certificate to"
 msgstr  ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid   "List profiles"
 msgstr  ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid   "List projects"
 msgstr  ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid   "List storage bucket keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid   "List storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -2722,19 +2712,19 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid   "List the available remotes"
 msgstr  ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid   "List trusted clients"
 msgstr  ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid   "List warnings"
 msgstr  ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid   "List warnings\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -2756,11 +2746,11 @@ msgid   "List warnings\n"
         "    t - Type"
 msgstr  ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -2769,91 +2759,91 @@ msgstr  ""
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid   "Log:"
 msgstr  ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid   "Lower device"
 msgstr  ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid   "Lower devices"
 msgstr  ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid   "MAC address"
 msgstr  ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid   "MAC address: %s"
 msgstr  ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid   "MAD: %s (%s)"
 msgstr  ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid   "MANAGED"
 msgstr  ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid   "MEMBERS"
 msgstr  ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid   "MEMORY USAGE"
 msgstr  ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid   "MEMORY USAGE%"
 msgstr  ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid   "MESSAGE"
 msgstr  ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid   "MII Frequency"
 msgstr  ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid   "MII state"
 msgstr  ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid   "MTU"
 msgstr  ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid   "MTU: %d"
 msgstr  ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid   "Make image public"
 msgstr  ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid   "Make the image public"
 msgstr  ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid   "Manage and attach instances to networks"
 msgstr  ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid   "Manage cluster groups"
 msgstr  ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid   "Manage cluster members"
 msgstr  ""
 
@@ -2861,7 +2851,7 @@ msgstr  ""
 msgid   "Manage cluster roles"
 msgstr  ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid   "Manage command aliases"
 msgstr  ""
 
@@ -2869,19 +2859,19 @@ msgstr  ""
 msgid   "Manage devices"
 msgstr  ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid   "Manage files in instances"
 msgstr  ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid   "Manage image aliases"
 msgstr  ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid   "Manage images"
 msgstr  ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid   "Manage images\n"
         "\n"
         "In LXD instances are created from images. Those images were themselves\n"
@@ -2903,7 +2893,7 @@ msgstr  ""
 msgid   "Manage instance and server configuration options"
 msgstr  ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid   "Manage instance file templates"
 msgstr  ""
 
@@ -2911,106 +2901,106 @@ msgstr  ""
 msgid   "Manage instance metadata files"
 msgstr  ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid   "Manage network ACL rules"
 msgstr  ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid   "Manage network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid   "Manage network forward ports"
 msgstr  ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid   "Manage network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid   "Manage network load balancer backends"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid   "Manage network load balancer ports"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid   "Manage network load balancers"
 msgstr  ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid   "Manage network peerings"
 msgstr  ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid   "Manage network zone record entries"
 msgstr  ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid   "Manage network zone records"
 msgstr  ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid   "Manage network zones"
 msgstr  ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid   "Manage profiles"
 msgstr  ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid   "Manage projects"
 msgstr  ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid   "Manage storage bucket keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid   "Manage storage bucket keys."
 msgstr  ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid   "Manage storage buckets"
 msgstr  ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid   "Manage storage buckets."
 msgstr  ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid   "Manage storage pools and volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid   "Manage storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid   "Manage storage volumes\n"
         "\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
 msgstr  ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid   "Manage the list of remote servers"
 msgstr  ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid   "Manage trusted clients"
 msgstr  ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid   "Manage warnings"
 msgstr  ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid   "Maximum number of VFs: %d"
 msgstr  ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid   "Mdev profiles:"
 msgstr  ""
 
@@ -3024,43 +3014,43 @@ msgstr  ""
 msgid   "Member %q does not have role %q"
 msgstr  ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid   "Member %s join token:"
 msgstr  ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid   "Member %s removed"
 msgstr  ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid   "Member %s renamed to %s"
 msgstr  ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid   "Memory (current)"
 msgstr  ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid   "Memory usage:"
 msgstr  ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid   "Memory:"
 msgstr  ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid   "Migration API failure: %w"
 msgstr  ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid   "Migration operation failure: %w"
 msgstr  ""
@@ -3069,31 +3059,31 @@ msgstr  ""
 msgid   "Minimum level for log messages (only available when using pretty format)"
 msgstr  ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212 lxc/storage_bucket.go:288 lxc/storage_bucket.go:404 lxc/storage_bucket.go:549 lxc/storage_bucket.go:625 lxc/storage_bucket.go:761 lxc/storage_bucket.go:842 lxc/storage_bucket.go:917 lxc/storage_bucket.go:996 lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211 lxc/storage_bucket.go:287 lxc/storage_bucket.go:403 lxc/storage_bucket.go:548 lxc/storage_bucket.go:624 lxc/storage_bucket.go:760 lxc/storage_bucket.go:841 lxc/storage_bucket.go:916 lxc/storage_bucket.go:995 lxc/storage_bucket.go:1118
 msgid   "Missing bucket name"
 msgstr  ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid   "Missing certificate fingerprint"
 msgstr  ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279 lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278 lxc/cluster_group.go:580
 msgid   "Missing cluster group name"
 msgstr  ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110 lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109 lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid   "Missing cluster member name"
 msgstr  ""
 
-#: lxc/config_metadata.go:103 lxc/config_metadata.go:204 lxc/config_template.go:92 lxc/config_template.go:135 lxc/config_template.go:177 lxc/config_template.go:266 lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201 lxc/profile.go:674
+#: lxc/config_metadata.go:103 lxc/config_metadata.go:204 lxc/config_template.go:91 lxc/config_template.go:134 lxc/config_template.go:176 lxc/config_template.go:265 lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200 lxc/profile.go:673
 msgid   "Missing instance name"
 msgstr  ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921 lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920 lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid   "Missing key name"
 msgstr  ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260 lxc/network_forward.go:355 lxc/network_forward.go:415 lxc/network_forward.go:539 lxc/network_forward.go:658 lxc/network_forward.go:735 lxc/network_forward.go:801 lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262 lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417 lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661 lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259 lxc/network_forward.go:354 lxc/network_forward.go:414 lxc/network_forward.go:538 lxc/network_forward.go:657 lxc/network_forward.go:734 lxc/network_forward.go:800 lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416 lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660 lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800 lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid   "Missing listen address"
 msgstr  ""
 
@@ -3101,68 +3091,68 @@ msgstr  ""
 msgid   "Missing name"
 msgstr  ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287 lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534 lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806 lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286 lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533 lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805 lxc/network_acl.go:872
 msgid   "Missing network ACL name"
 msgstr  ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443 lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799 lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139 lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192 lxc/network_forward.go:256 lxc/network_forward.go:351 lxc/network_forward.go:411 lxc/network_forward.go:535 lxc/network_forward.go:654 lxc/network_forward.go:731 lxc/network_forward.go:797 lxc/network_load_balancer.go:120 lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413 lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657 lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797 lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960 lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238 lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519 lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442 lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798 lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138 lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191 lxc/network_forward.go:255 lxc/network_forward.go:350 lxc/network_forward.go:410 lxc/network_forward.go:534 lxc/network_forward.go:653 lxc/network_forward.go:730 lxc/network_forward.go:796 lxc/network_load_balancer.go:119 lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257 lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412 lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656 lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796 lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959 lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237 lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518 lxc/network_peer.go:627
 msgid   "Missing network name"
 msgstr  ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282 lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568 lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841 lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186 lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281 lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567 lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840 lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185 lxc/network_zone.go:1230
 msgid   "Missing network zone name"
 msgstr  ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid   "Missing network zone record name"
 msgstr  ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357 lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356 lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429 lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108 lxc/storage_bucket.go:208 lxc/storage_bucket.go:284 lxc/storage_bucket.go:400 lxc/storage_bucket.go:466 lxc/storage_bucket.go:545 lxc/storage_bucket.go:621 lxc/storage_bucket.go:757 lxc/storage_bucket.go:838 lxc/storage_bucket.go:913 lxc/storage_bucket.go:992 lxc/storage_bucket.go:1115 lxc/storage_volume.go:188 lxc/storage_volume.go:263 lxc/storage_volume.go:555 lxc/storage_volume.go:632 lxc/storage_volume.go:707 lxc/storage_volume.go:789 lxc/storage_volume.go:888 lxc/storage_volume.go:1075 lxc/storage_volume.go:1401 lxc/storage_volume.go:1626 lxc/storage_volume.go:1741 lxc/storage_volume.go:1833 lxc/storage_volume.go:1961 lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428 lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107 lxc/storage_bucket.go:207 lxc/storage_bucket.go:283 lxc/storage_bucket.go:399 lxc/storage_bucket.go:465 lxc/storage_bucket.go:544 lxc/storage_bucket.go:620 lxc/storage_bucket.go:756 lxc/storage_bucket.go:837 lxc/storage_bucket.go:912 lxc/storage_bucket.go:991 lxc/storage_bucket.go:1114 lxc/storage_volume.go:187 lxc/storage_volume.go:262 lxc/storage_volume.go:554 lxc/storage_volume.go:631 lxc/storage_volume.go:706 lxc/storage_volume.go:788 lxc/storage_volume.go:887 lxc/storage_volume.go:1074 lxc/storage_volume.go:1400 lxc/storage_volume.go:1625 lxc/storage_volume.go:1740 lxc/storage_volume.go:1832 lxc/storage_volume.go:1960 lxc/storage_volume.go:2055
 msgid   "Missing pool name"
 msgstr  ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564 lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563 lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid   "Missing profile name"
 msgstr  ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372 lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371 lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid   "Missing project name"
 msgstr  ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid   "Missing target directory"
 msgstr  ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid   "Missing target network"
 msgstr  ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid   "Mode"
 msgstr  ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid   "Model: %s"
 msgstr  ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid   "Model: %v"
 msgstr  ""
@@ -3177,23 +3167,23 @@ msgid   "Monitor a local or remote LXD server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727 lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726 lxc/storage_volume.go:807
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid   "Mount files from instances"
 msgstr  ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid   "Move instances within or in between LXD servers"
 msgstr  ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid   "Move instances within or in between LXD servers\n"
         "\n"
         "Transfer modes (--mode):\n"
@@ -3204,253 +3194,253 @@ msgid   "Move instances within or in between LXD servers\n"
         "The pull transfer mode is the default as it is compatible with all LXD versions.\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid   "Move to a project different from the source"
 msgstr  ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid   "Moving the storage volume: %s"
 msgstr  ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid   "Multiple ports match. Use --force to remove them all"
 msgstr  ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid   "Multiple rules match. Use --force to remove them all"
 msgstr  ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422 lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566 lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633 lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627 lxc/storage_bucket.go:495 lxc/storage_bucket.go:790 lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632 lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626 lxc/storage_bucket.go:494 lxc/storage_bucket.go:789 lxc/storage_volume.go:1465
 msgid   "NAME"
 msgstr  ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid   "NETWORK ZONES"
 msgstr  ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid   "NETWORKS"
 msgstr  ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid   "NIC:"
 msgstr  ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444 lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464 lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443 lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463 lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid   "NO"
 msgstr  ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid   "NUMA node: %v"
 msgstr  ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid   "NUMA nodes:\n"
 msgstr  ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid   "NVIDIA information:"
 msgstr  ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277 lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276 lxc/storage_volume.go:1326
 msgid   "Name"
 msgstr  ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid   "Name: %v"
 msgstr  ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid   "Network %s created"
 msgstr  ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid   "Network %s deleted"
 msgstr  ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid   "Network %s pending on member %s"
 msgstr  ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid   "Network %s renamed to %s"
 msgstr  ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid   "Network ACL %s created"
 msgstr  ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid   "Network ACL %s deleted"
 msgstr  ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid   "Network ACL %s renamed to %s"
 msgstr  ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid   "Network Zone %s created"
 msgstr  ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid   "Network Zone %s deleted"
 msgstr  ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid   "Network forward %s created"
 msgstr  ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid   "Network forward %s deleted"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid   "Network load balancer %s created"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid   "Network load balancer %s deleted"
 msgstr  ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid   "Network name"
 msgstr  ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid   "Network peer %s created"
 msgstr  ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid   "Network peer %s deleted"
 msgstr  ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid   "Network peer %s is in unexpected state %q"
 msgstr  ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid   "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr  ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid   "Network type"
 msgstr  ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid   "Network usage:"
 msgstr  ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid   "Network zone record %s created"
 msgstr  ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid   "Network zone record %s deleted"
 msgstr  ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid   "New alias to define at target"
 msgstr  ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid   "New aliases to add to the image"
 msgstr  ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid   "No certificate add token for member %s on remote: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid   "No cluster join token for member %s on remote: %s"
 msgstr  ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid   "No device found for this network"
 msgstr  ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid   "No device found for this storage volume"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid   "No matching backend found"
 msgstr  ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid   "No matching port(s) found"
 msgstr  ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid   "No matching rule(s) found"
 msgstr  ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
@@ -3459,53 +3449,53 @@ msgstr  ""
 msgid   "No value found in %q"
 msgstr  ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid   "Node %d:\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid   "Not a snapshot name"
 msgstr  ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid   "OVN:"
 msgstr  ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid   "Only \"custom\" volumes can be attached to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid   "Only managed networks can be modified"
 msgstr  ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -3517,57 +3507,57 @@ msgstr  ""
 msgid   "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr  ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid   "PCI address: %v"
 msgstr  ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid   "PEER"
 msgstr  ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid   "PID"
 msgstr  ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid   "PID: %d"
 msgstr  ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid   "PORTS"
 msgstr  ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid   "PUBLIC"
 msgstr  ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid   "Packets received"
 msgstr  ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid   "Packets sent"
 msgstr  ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid   "Partitions:"
 msgstr  ""
 
@@ -3576,44 +3566,44 @@ msgstr  ""
 msgid   "Password for %s: "
 msgstr  ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid   "Pause instances"
 msgstr  ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid   "Perform an incremental copy"
 msgstr  ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid   "Please provide an alternate server address (empty to abort):"
 msgstr  ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid   "Please provide client name: "
 msgstr  ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid   "Port type: %s"
 msgstr  ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264 lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207 lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684 lxc/network_acl.go:583 lxc/network_forward.go:598 lxc/network_load_balancer.go:601 lxc/network_peer.go:574 lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509 lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345 lxc/storage_bucket.go:1057 lxc/storage_volume.go:986 lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264 lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582 lxc/network_forward.go:597 lxc/network_load_balancer.go:600 lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056 lxc/storage_volume.go:985 lxc/storage_volume.go:1017
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -3633,7 +3623,7 @@ msgstr  ""
 msgid   "Print version number"
 msgstr  ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
@@ -3643,125 +3633,125 @@ msgstr  ""
 msgid   "Processing aliases failed: %s"
 msgstr  ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid   "Product: %v (%v)"
 msgstr  ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid   "Profile %s added to %s"
 msgstr  ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid   "Profile %s created"
 msgstr  ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid   "Profile %s deleted"
 msgstr  ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid   "Profile %s isn't currently applied to %s"
 msgstr  ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid   "Profile %s removed from %s"
 msgstr  ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid   "Profile %s renamed to %s"
 msgstr  ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid   "Profile to apply to the new image"
 msgstr  ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid   "Profile to apply to the new instance"
 msgstr  ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid   "Profile to apply to the target instance"
 msgstr  ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid   "Profiles %s applied to %s"
 msgstr  ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid   "Profiles:"
 msgstr  ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid   "Profiles: "
 msgstr  ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid   "Project %s created"
 msgstr  ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid   "Project %s deleted"
 msgstr  ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid   "Project %s renamed to %s"
 msgstr  ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid   "Project to use for the remote"
 msgstr  ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid   "Property not found"
 msgstr  ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid   "Public image server"
 msgstr  ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid   "Public: %s"
 msgstr  ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid   "Publish instances as images"
 msgstr  ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -3770,87 +3760,83 @@ msgstr  ""
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid   "Query virtual machine images"
 msgstr  ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid   "RESOURCE"
 msgstr  ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid   "ROLE"
 msgstr  ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid   "ROLES"
 msgstr  ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid   "Read-Only: %v"
 msgstr  ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid   "Recursively transfer files"
 msgstr  ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid   "Refresh images"
 msgstr  ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900 lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899 lxc/remote.go:937
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid   "Remote admin password"
 msgstr  ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
-#: lxc/utils/cancel.go:59
-msgid   "Remote operation canceled by user"
-msgstr  ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid   "Removable: %v"
 msgstr  ""
@@ -3860,39 +3846,39 @@ msgstr  ""
 msgid   "Remove %s (yes/no): "
 msgstr  ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid   "Remove a cluster member from a cluster group"
 msgstr  ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid   "Remove a network zone record entry"
 msgstr  ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid   "Remove aliases"
 msgstr  ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid   "Remove all ports that match"
 msgstr  ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid   "Remove all rules that match"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid   "Remove backend from a load balancer"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid   "Remove backends from a load balancer"
 msgstr  ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid   "Remove entries from a network zone record"
 msgstr  ""
 
@@ -3900,23 +3886,23 @@ msgstr  ""
 msgid   "Remove instance devices"
 msgstr  ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid   "Remove member from group"
 msgstr  ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid   "Remove ports from a forward"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid   "Remove ports from a load balancer"
 msgstr  ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -3924,23 +3910,23 @@ msgstr  ""
 msgid   "Remove roles from a cluster member"
 msgstr  ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid   "Remove rules from an ACL"
 msgstr  ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid   "Remove trusted client"
 msgstr  ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid   "Rename a cluster group"
 msgstr  ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid   "Rename a cluster member"
 msgstr  ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255 lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254 lxc/image_alias.go:255
 msgid   "Rename aliases"
 msgstr  ""
 
@@ -3948,45 +3934,45 @@ msgstr  ""
 msgid   "Rename instances and snapshots"
 msgstr  ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid   "Rename network ACLs"
 msgstr  ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid   "Rename networks"
 msgstr  ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid   "Rename profiles"
 msgstr  ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid   "Rename remotes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid   "Rename storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid   "Rename storage volumes and storage volume snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid   "Render: %s (%s)"
 msgstr  ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
@@ -3994,21 +3980,21 @@ msgstr  ""
 msgid   "Require user confirmation"
 msgstr  ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid   "Resources:"
 msgstr  ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid   "Restart instances"
 msgstr  ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid   "Restart instances\n"
         "\n"
         "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr  ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid   "Restore cluster member"
 msgstr  ""
 
@@ -4022,16 +4008,16 @@ msgid   "Restore instances from snapshots\n"
         "If --stateful is passed, then the running state will be restored too."
 msgstr  ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid   "Restoring cluster member: %s"
 msgstr  ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid   "Restrict the certificate to one or more projects"
 msgstr  ""
 
@@ -4039,90 +4025,90 @@ msgstr  ""
 msgid   "Retrieve the instance's console log"
 msgstr  ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid   "Revoke certificate add token"
 msgstr  ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid   "Revoke cluster member join token"
 msgstr  ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid   "Role (admin or read-only)"
 msgstr  ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid   "Run against all instances"
 msgstr  ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid   "SEVERITY"
 msgstr  ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid   "SIZE"
 msgstr  ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid   "SNAPSHOTS"
 msgstr  ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid   "SOURCE"
 msgstr  ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971 lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970 lxc/network_peer.go:142 lxc/storage.go:636
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid   "STATIC"
 msgstr  ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid   "STATUS"
 msgstr  ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid   "STORAGE BUCKETS"
 msgstr  ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid   "STORAGE VOLUMES"
 msgstr  ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid   "STP"
 msgstr  ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid   "Secret key (auto-generated if empty)"
 msgstr  ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid   "Secret key: %s"
 msgstr  ""
@@ -4131,19 +4117,19 @@ msgstr  ""
 msgid   "Send a raw query to LXD"
 msgstr  ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid   "Server authentication type (tls, candid, or oidc)"
 msgstr  ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid   "Server protocol (lxd or simplestreams)"
 msgstr  ""
 
@@ -4152,11 +4138,11 @@ msgstr  ""
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -4178,7 +4164,7 @@ msgid   "Set device configuration keys\n"
         "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid   "Set image properties"
 msgstr  ""
 
@@ -4193,148 +4179,148 @@ msgid   "Set instance or server configuration keys\n"
         "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr  ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid   "Set network ACL configuration keys"
 msgstr  ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid   "Set network ACL configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr  ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid   "Set network configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid   "Set network configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr  ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid   "Set network forward keys"
 msgstr  ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid   "Set network forward keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid   "Set network load balancer keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid   "Set network load balancer keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr  ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid   "Set network peer keys"
 msgstr  ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid   "Set network peer keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr  ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid   "Set network zone configuration keys"
 msgstr  ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid   "Set network zone configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr  ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid   "Set network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid   "Set profile configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid   "Set profile configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr  ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid   "Set project configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid   "Set storage bucket configuration keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid   "Set storage bucket configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr  ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid   "Set storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid   "Set storage pool configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid   "Set the file's uid on push"
 msgstr  ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -4346,19 +4332,19 @@ msgstr  ""
 msgid   "Show all information messages"
 msgstr  ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid   "Show cluster group configurations"
 msgstr  ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid   "Show content of instance file templates"
 msgstr  ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid   "Show details of a cluster member"
 msgstr  ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid   "Show details on a background operation"
 msgstr  ""
 
@@ -4370,7 +4356,7 @@ msgstr  ""
 msgid   "Show full device configuration"
 msgstr  ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid   "Show image properties"
 msgstr  ""
 
@@ -4382,7 +4368,7 @@ msgstr  ""
 msgid   "Show instance or server configurations"
 msgstr  ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid   "Show instance or server information"
 msgstr  ""
 
@@ -4394,71 +4380,71 @@ msgstr  ""
 msgid   "Show local and remote versions"
 msgstr  ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid   "Show network ACL configurations"
 msgstr  ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid   "Show network ACL log"
 msgstr  ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid   "Show network configurations"
 msgstr  ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid   "Show network forward configurations"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid   "Show network load balancer configurations"
 msgstr  ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid   "Show network peer configurations"
 msgstr  ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid   "Show network zone configurations"
 msgstr  ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid   "Show network zone record configuration"
 msgstr  ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid   "Show network zone record configurations"
 msgstr  ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid   "Show profile configurations"
 msgstr  ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid   "Show project options"
 msgstr  ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid   "Show storage bucket configurations"
 msgstr  ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid   "Show storage bucket key configurations"
 msgstr  ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -4466,114 +4452,114 @@ msgstr  ""
 msgid   "Show the expanded configuration"
 msgstr  ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid   "Show the instance's last 100 log lines?"
 msgstr  ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid   "Show the resources available to the server"
 msgstr  ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid   "Show the resources available to the storage pool"
 msgstr  ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid   "Show the used and free space in bytes"
 msgstr  ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid   "Show trust configurations"
 msgstr  ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid   "Show useful information about a cluster member"
 msgstr  ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid   "Show useful information about images"
 msgstr  ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid   "Show useful information about storage pools"
 msgstr  ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid   "Show warning"
 msgstr  ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid   "Size: %.2fMB"
 msgstr  ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid   "Size: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid   "Snapshots:"
 msgstr  ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid   "Socket %d:"
 msgstr  ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid   "Some instances failed to %s"
 msgstr  ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid   "Source:"
 msgstr  ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid   "Start instances"
 msgstr  ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid   "Starting %s"
 msgstr  ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid   "State"
 msgstr  ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid   "State: %s"
 msgstr  ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid   "Stateful"
 msgstr  ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid   "Status: %s"
 msgstr  ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid   "Stop instances"
 msgstr  ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid   "Stop the instance if currently running"
 msgstr  ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid   "Stopping instance failed!"
 msgstr  ""
 
@@ -4582,135 +4568,135 @@ msgstr  ""
 msgid   "Stopping the instance failed: %s"
 msgstr  ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid   "Storage bucket %s created"
 msgstr  ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid   "Storage bucket %s deleted"
 msgstr  ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid   "Storage bucket key %s added"
 msgstr  ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid   "Storage bucket key %s removed"
 msgstr  ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid   "Storage pool %s created"
 msgstr  ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid   "Storage pool %s deleted"
 msgstr  ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid   "Storage pool name"
 msgstr  ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid   "Storage volume copied successfully!"
 msgstr  ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid   "Store the instance state"
 msgstr  ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid   "Successfully updated cluster certificates for remote %s"
 msgstr  ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid   "Supported modes: %s"
 msgstr  ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid   "Supported ports: %s"
 msgstr  ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid   "Swap (current)"
 msgstr  ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid   "Switch the default remote"
 msgstr  ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid   "TARGET"
 msgstr  ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237 lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163 lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162 lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid   "Target path must be a directory"
 msgstr  ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid   "The --instance-only flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid   "The --mode flag can't be used with --storage"
 msgstr  ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid   "The --mode flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid   "The --mode flag can't be used with --target-project"
 msgstr  ""
 
@@ -4718,15 +4704,15 @@ msgstr  ""
 msgid   "The --show-log flag is only supported for by 'console' output type"
 msgstr  ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid   "The --storage flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid   "The --target-project flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid   "The destination LXD server is not clustered"
 msgstr  ""
 
@@ -4734,7 +4720,7 @@ msgstr  ""
 msgid   "The device already exists"
 msgstr  ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid   "The direction argument must be one of: ingress, egress"
 msgstr  ""
 
@@ -4742,15 +4728,15 @@ msgstr  ""
 msgid   "The instance is currently running, stop it first or pass --force"
 msgstr  ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid   "The key %q does not exist on cluster member %q"
 msgstr  ""
@@ -4769,31 +4755,31 @@ msgstr  ""
 msgid   "The profile device doesn't exist"
 msgstr  ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741 lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740 lxc/storage_volume.go:821
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid   "The specified device doesn't match the network"
 msgstr  ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid   "This LXD server is already clustered"
 msgstr  ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid   "This LXD server is not available on the network"
 msgstr  ""
 
@@ -4805,23 +4791,23 @@ msgid   "This client hasn't been configured to use a remote LXD server yet.\n"
         "To easily setup a local LXD server in a virtual machine, consider using: https://multipass.run"
 msgstr  ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid   "Threads:"
 msgstr  ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid   "Time to wait for the instance to shutdown cleanly"
 msgstr  ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid   "To attach a network to an instance, use: lxc network attach"
 msgstr  ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
@@ -4834,69 +4820,69 @@ msgid   "To start your first container, try: lxc launch ubuntu:22.04\n"
         "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668 lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668 lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid   "Total: %v"
 msgstr  ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid   "Transfer mode. One of pull, push or relay"
 msgstr  ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid   "Transfer mode. One of pull, push or relay."
 msgstr  ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid   "Transmit policy"
 msgstr  ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid   "Type"
 msgstr  ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid   "Type of certificate"
 msgstr  ""
 
@@ -4904,65 +4890,65 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821 lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820 lxc/storage_volume.go:1225
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid   "UNLIMITED"
 msgstr  ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141 lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636 lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140 lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635 lxc/storage_volume.go:1468
 msgid   "USED BY"
 msgstr  ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid   "UUID"
 msgstr  ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid   "UUID: %v"
 msgstr  ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid   "Unavailable remote server"
 msgstr  ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503 lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502 lxc/warning.go:243
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -4972,12 +4958,12 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid   "Unknown key: %s"
 msgstr  ""
@@ -4987,11 +4973,11 @@ msgstr  ""
 msgid   "Unknown output type %q"
 msgstr  ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid   "Unset a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid   "Unset all profiles on the target instance"
 msgstr  ""
 
@@ -4999,7 +4985,7 @@ msgstr  ""
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid   "Unset image properties"
 msgstr  ""
 
@@ -5007,98 +4993,98 @@ msgstr  ""
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid   "Unset network ACL configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid   "Unset network configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid   "Unset network forward configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid   "Unset network forward keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid   "Unset network load balancer configuration keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid   "Unset network load balancer keys"
 msgstr  ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid   "Unset network peer configuration keys"
 msgstr  ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid   "Unset network peer keys"
 msgstr  ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid   "Unset network zone configuration keys"
 msgstr  ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid   "Unset network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid   "Unset project configuration keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid   "Unset storage bucket configuration keys"
 msgstr  ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid   "Unsupported instance type: %s"
 msgstr  ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid   "Up delay"
 msgstr  ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid   "Update cluster certificate"
 msgstr  ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid   "Update cluster certificate with PEM certificate and key read from input files."
 msgstr  ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid   "Uploaded: %s"
 msgstr  ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid   "Upper devices"
 msgstr  ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -5106,7 +5092,7 @@ msgstr  ""
 msgid   "Use with help or --help to view sub-commands"
 msgstr  ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid   "Used: %v"
 msgstr  ""
@@ -5115,51 +5101,51 @@ msgstr  ""
 msgid   "User ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid   "User aborted delete operation"
 msgstr  ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid   "User signaled us three times, exiting. The remote operation will keep running"
 msgstr  ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid   "VFs: %d"
 msgstr  ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid   "VLAN ID"
 msgstr  ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid   "VLAN filtering"
 msgstr  ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid   "VLAN:"
 msgstr  ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid   "Vendor: %v"
 msgstr  ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid   "Vendor: %v (%v)"
 msgstr  ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid   "Verb: %s (%s)"
 msgstr  ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid   "Volume Only"
 msgstr  ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid   "WWN: %s"
 msgstr  ""
@@ -5168,7 +5154,7 @@ msgstr  ""
 msgid   "Wait for the operation to complete"
 msgstr  ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid   "Whether or not to only backup the instance (without snapshots)"
 msgstr  ""
 
@@ -5180,7 +5166,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the instance's running state"
 msgstr  ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446 lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445 lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid   "YES"
 msgstr  ""
 
@@ -5192,71 +5178,71 @@ msgstr  ""
 msgid   "You can't pass -t or -T at the same time as --mode"
 msgstr  ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid   "You must specify a destination instance name when using --target"
 msgstr  ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid   "You must specify a source instance name"
 msgstr  ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365 lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31 lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83 lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395 lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394 lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid   "[<remote>:]"
 msgstr  ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid   "[<remote>:] <backup file> [<instance name>]"
 msgstr  ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid   "[<remote>:] <cert.crt> <cert.key>"
 msgstr  ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid   "[<remote>:] [<cert>]"
 msgstr  ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid   "[<remote>:] [<filters>...]"
 msgstr  ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482 lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481 lxc/network_acl.go:660
 msgid   "[<remote>:]<ACL>"
 msgstr  ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid   "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid   "[<remote>:]<ACL> <key>"
 msgstr  ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid   "[<remote>:]<ACL> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid   "[<remote>:]<ACL> <new-name>"
 msgstr  ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid   "[<remote>:]<ACL> [key=value...]"
 msgstr  ""
 
@@ -5264,79 +5250,79 @@ msgstr  ""
 msgid   "[<remote>:]<API path>"
 msgstr  ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid   "[<remote>:]<Zone>"
 msgstr  ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid   "[<remote>:]<Zone> <key>"
 msgstr  ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid   "[<remote>:]<Zone> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid   "[<remote>:]<Zone> [key=value...]"
 msgstr  ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid   "[<remote>:]<alias>"
 msgstr  ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid   "[<remote>:]<alias> <fingerprint>"
 msgstr  ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid   "[<remote>:]<cluster member>"
 msgstr  ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid   "[<remote>:]<fingerprint>"
 msgstr  ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253 lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252 lxc/cluster_group.go:554
 msgid   "[<remote>:]<group>"
 msgstr  ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid   "[<remote>:]<group> <new-name>"
 msgstr  ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid   "[<remote>:]<image> <remote>:"
 msgstr  ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid   "[<remote>:]<image> [<remote>:][<name>]"
 msgstr  ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid   "[<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53 lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53 lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
@@ -5360,11 +5346,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid   "[<remote>:]<instance> <profile>"
 msgstr  ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid   "[<remote>:]<instance> <profiles>"
 msgstr  ""
 
@@ -5372,7 +5358,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <snapshot>"
 msgstr  ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108 lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107 lxc/config_template.go:150 lxc/config_template.go:298
 msgid   "[<remote>:]<instance> <template>"
 msgstr  ""
 
@@ -5380,7 +5366,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [<snapshot name>]"
 msgstr  ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid   "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr  ""
 
@@ -5388,23 +5374,23 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr  ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -5412,11 +5398,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid   "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr  ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid   "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
@@ -5424,23 +5410,23 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr  ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942 lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941 lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid   "[<remote>:]<member> <group>"
 msgstr  ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid   "[<remote>:]<member> <key>"
 msgstr  ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid   "[<remote>:]<member> <key>=<value>..."
 msgstr  ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid   "[<remote>:]<member> <new-name>"
 msgstr  ""
 
@@ -5448,199 +5434,199 @@ msgstr  ""
 msgid   "[<remote>:]<member> <role[,role...]>"
 msgstr  ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987 lxc/network.go:1178 lxc/network_forward.go:84 lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986 lxc/network.go:1177 lxc/network_forward.go:83 lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid   "[<remote>:]<network>"
 msgstr  ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid   "[<remote>:]<network> <instance> [<device name>]"
 msgstr  ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid   "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid   "[<remote>:]<network> <key>"
 msgstr  ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid   "[<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486 lxc/network_forward.go:627 lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485 lxc/network_forward.go:626 lxc/network_load_balancer.go:167 lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid   "[<remote>:]<network> <listen_address>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid   "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid   "[<remote>:]<network> <listen_address> <backend_name> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459 lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458 lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid   "[<remote>:]<network> <listen_address> <key>"
 msgstr  ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid   "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <backend_name>[,<backend_name>...]"
 msgstr  ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid   "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid   "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr  ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid   "[<remote>:]<network> <new-name>"
 msgstr  ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid   "[<remote>:]<network> <peer name>"
 msgstr  ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid   "[<remote>:]<network> <peer_name>"
 msgstr  ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid   "[<remote>:]<network> <peer_name> <[target project/]target_network> [key=value...]"
 msgstr  ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid   "[<remote>:]<network> <peer_name> <key>"
 msgstr  ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid   "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid   "[<remote>:]<network> <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid   "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid   "[<remote>:]<network> [key=value...]"
 msgstr  ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid   "[<remote>:]<operation>"
 msgstr  ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724 lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723 lxc/storage_bucket.go:437
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243 lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242 lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid   "[<remote>:]<pool> <bucket>"
 msgstr  ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659 lxc/storage_bucket.go:809 lxc/storage_bucket.go:887 lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658 lxc/storage_bucket.go:808 lxc/storage_bucket.go:886 lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid   "[<remote>:]<pool> <bucket> <key>"
 msgstr  ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid   "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid   "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr  ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid   "[<remote>:]<pool> <driver> [key=value...]"
 msgstr  ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid   "[<remote>:]<pool> <key>"
 msgstr  ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid   "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid   "[<remote>:]<pool> <volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid   "[<remote>:]<pool> <volume> <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid   "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844 lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843 lxc/storage_volume.go:1799
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid   "[<remote>:]<pool> [<filter>...]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308 lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307 lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid   "[<remote>:]<profile>"
 msgstr  ""
 
@@ -5656,11 +5642,11 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr  ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid   "[<remote>:]<profile> <key>"
 msgstr  ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid   "[<remote>:]<profile> <key><value>..."
 msgstr  ""
 
@@ -5668,59 +5654,59 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid   "[<remote>:]<profile> <new-name>"
 msgstr  ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653 lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652 lxc/project.go:705
 msgid   "[<remote>:]<project>"
 msgstr  ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid   "[<remote>:]<project> <key>"
 msgstr  ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid   "[<remote>:]<project> <key>=<value>..."
 msgstr  ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid   "[<remote>:]<project> <new-name>"
 msgstr  ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid   "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr  ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid   "[<remote>:]<warning-uuid>"
 msgstr  ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid   "[<remote>:]<zone>"
 msgstr  ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid   "[<remote>:]<zone> <record>"
 msgstr  ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid   "[<remote>:]<zone> <record> <key>"
 msgstr  ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid   "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid   "[<remote>:]<zone> <record> <type> <value>"
 msgstr  ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 
@@ -5728,7 +5714,7 @@ msgstr  ""
 msgid   "[<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid   "[<remote>:][<instance>]"
 msgstr  ""
 
@@ -5740,64 +5726,64 @@ msgstr  ""
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid   "[<remote>] <IP|FQDN|URL|token>"
 msgstr  ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid   "[[<remote>:]<name>]"
 msgstr  ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid   "current"
 msgstr  ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid   "description"
 msgstr  ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid   "disabled"
 msgstr  ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid   "driver"
 msgstr  ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid   "enabled"
 msgstr  ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid   "error: %v"
 msgstr  ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid   "info"
 msgstr  ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid   "lxc alias add list \"list -c ns46S\"\n"
         "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr  ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid   "lxc alias remove my-list\n"
         "    Remove the \"my-list\" alias."
 msgstr  ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid   "lxc alias rename list my-list\n"
         "    Rename existing alias \"list\" to \"my-list\"."
 msgstr  ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid   "lxc cluster edit <cluster member> < member.yaml\n"
         "    Update a cluster member using the content of member.yaml"
 msgstr  ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid   "lxc cluster group assign foo default,bar\n"
         "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
         "\n"
@@ -5829,27 +5815,27 @@ msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will set the server's trust password to blah."
 msgstr  ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid   "lxc image edit <image>\n"
         "    Launch a text editor to edit the properties\n"
         "\n"
@@ -5857,12 +5843,12 @@ msgid   "lxc image edit <image>\n"
         "    Load the image properties from a YAML file"
 msgstr  ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid   "lxc import backup0.tar.gz\n"
         "    Create a new instance using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid   "lxc info [<remote>:]<instance> [--show-log]\n"
         "    For instance information.\n"
         "\n"
@@ -5870,14 +5856,14 @@ msgid   "lxc info [<remote>:]<instance> [--show-log]\n"
         "    For LXD server information."
 msgstr  ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid   "lxc init ubuntu:22.04 u1\n"
         "\n"
         "lxc init ubuntu:22.04 u1 < config.yaml\n"
         "    Create the instance with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid   "lxc launch ubuntu:22.04 u1\n"
         "\n"
         "lxc launch ubuntu:22.04 u1 < config.yaml\n"
@@ -5890,7 +5876,7 @@ msgid   "lxc launch ubuntu:22.04 u1\n"
         "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr  ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid   "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
         "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", \"IPV6\" and \"MAC\" columns.\n"
         "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from instance configuration keys.\n"
@@ -5911,7 +5897,7 @@ msgid   "lxc monitor --type=logging\n"
         "    Only show lifecycle events."
 msgstr  ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid   "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--instance-only]\n"
         "    Move an instance between two hosts, renaming it if destination name differs.\n"
         "\n"
@@ -5922,7 +5908,7 @@ msgid   "lxc move [<remote>:]<source instance> [<remote>:][<destination instance
         "    Rename a snapshot."
 msgstr  ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid   "lxc network create foo\n"
         "    Create a new network called foo\n"
         "\n"
@@ -5930,12 +5916,12 @@ msgid   "lxc network create foo\n"
         "    Create a new OVN network called bar using baz as its uplink network"
 msgstr  ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid   "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
         "    Show details on that operation UUID"
 msgstr  ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid   "lxc profile assign foo default,bar\n"
         "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
         "\n"
@@ -5954,12 +5940,12 @@ msgid   "lxc profile device add [<remote>:]profile1 <device-name> disk source=/s
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid   "lxc profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid   "lxc project edit <project> < project.yaml\n"
         "    Update a project using the content of project.yaml"
 msgstr  ""
@@ -5982,42 +5968,42 @@ msgid   "lxc snapshot u1 snap0\n"
         "    Restore the snapshot."
 msgstr  ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid   "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
         "    Update a storage bucket using the content of bucket.yaml."
 msgstr  ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid   "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
         "    Update a storage bucket key using the content of key.yaml."
 msgstr  ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid   "lxc storage bucket key show default data foo\n"
         "    Will show the properties of a bucket key called \"foo\" for a bucket called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid   "lxc storage bucket show default data\n"
         "    Will show the properties of a bucket called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid   "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid   "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
         "    Update a storage volume using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid   "lxc storage volume show default data\n"
         "    Will show the properties of a custom volume called \"data\" in the \"default\" pool.\n"
         "\n"
@@ -6025,19 +6011,19 @@ msgid   "lxc storage volume show default data\n"
         "    Will show the properties of the filesystem for a container called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid   "n"
 msgstr  ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid   "name"
 msgstr  ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -6045,24 +6031,24 @@ msgstr  ""
 msgid   "please use `lxc profile`"
 msgstr  ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid   "total space"
 msgstr  ""
 
@@ -6070,15 +6056,15 @@ msgstr  ""
 msgid   "unreachable"
 msgstr  ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931 lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930 lxc/image.go:1115
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -43,7 +43,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -99,7 +99,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -114,7 +114,7 @@ msgstr ""
 "### Bijvoorbeeld:\n"
 "###  description: Mijn eigen image"
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -166,7 +166,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -225,7 +225,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -267,7 +267,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -305,7 +305,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -343,7 +343,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -374,7 +374,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -399,7 +399,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -424,7 +424,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -458,7 +458,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -497,7 +497,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -532,74 +532,69 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, fuzzy, c-format
 msgid "%s (%d available)"
 msgstr "%s (en nog %d)"
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr "(geen)"
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -607,11 +602,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -619,44 +614,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -665,31 +660,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -698,7 +693,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -711,19 +706,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -731,15 +726,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -751,11 +746,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -772,15 +767,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -788,76 +783,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -866,35 +861,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -910,48 +905,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -960,118 +955,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1080,15 +1075,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1096,11 +1091,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1109,70 +1104,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1181,85 +1176,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1275,34 +1270,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1311,33 +1306,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1345,11 +1340,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1369,114 +1364,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1492,149 +1487,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1642,72 +1637,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1715,112 +1710,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1865,16 +1860,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1882,7 +1877,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1894,28 +1889,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1923,54 +1918,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1982,73 +1977,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2063,7 +2058,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -2071,25 +2066,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2117,80 +2112,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2205,37 +2200,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2245,31 +2240,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2279,26 +2274,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2308,35 +2303,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2344,11 +2339,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2360,7 +2355,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2384,16 +2379,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2405,7 +2400,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2414,30 +2409,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2445,23 +2440,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2473,55 +2468,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2530,85 +2525,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2622,94 +2617,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2717,42 +2712,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2762,23 +2757,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2791,7 +2781,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2801,31 +2791,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2833,60 +2823,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2898,123 +2888,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -3045,15 +3035,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -3136,31 +3126,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3179,19 +3169,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -3214,11 +3204,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3227,91 +3217,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3319,7 +3309,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3327,19 +3317,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3362,7 +3352,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3370,108 +3360,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3485,43 +3475,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3531,51 +3521,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3585,107 +3575,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3701,24 +3691,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3734,263 +3724,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3999,53 +3989,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4057,57 +4047,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4116,52 +4106,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4181,7 +4171,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4191,125 +4181,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4318,88 +4308,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4409,39 +4395,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4449,23 +4435,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4473,24 +4459,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4498,45 +4484,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4544,22 +4530,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4574,16 +4560,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4591,91 +4577,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4684,19 +4670,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4705,11 +4691,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4735,7 +4721,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4752,11 +4738,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4765,11 +4751,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4778,11 +4764,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4791,11 +4777,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4804,11 +4790,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4817,11 +4803,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4830,15 +4816,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4847,11 +4833,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4860,11 +4846,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4873,11 +4859,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4886,11 +4872,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4899,23 +4885,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4927,19 +4913,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4951,7 +4937,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4963,7 +4949,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4975,71 +4961,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5047,114 +5033,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5163,137 +5149,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5301,15 +5287,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5317,7 +5303,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5325,17 +5311,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5354,32 +5340,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5395,23 +5381,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5426,69 +5412,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5498,69 +5484,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5570,12 +5556,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5585,11 +5571,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5597,7 +5583,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5605,100 +5591,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5707,7 +5693,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5716,52 +5702,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5770,7 +5756,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5784,9 +5770,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5798,76 +5784,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5875,81 +5861,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5973,11 +5959,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5985,8 +5971,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5994,7 +5980,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6002,24 +5988,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6027,11 +6013,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6040,24 +6026,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6065,220 +6051,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6294,11 +6280,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6306,60 +6292,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6367,7 +6353,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6379,68 +6365,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6478,32 +6464,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6512,13 +6498,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6527,7 +6513,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6535,7 +6521,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6550,7 +6536,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6576,7 +6562,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6590,7 +6576,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6599,13 +6585,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6628,13 +6614,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6661,74 +6647,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6736,24 +6722,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6761,16 +6747,16 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,7 +20,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -44,7 +44,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -72,7 +72,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -116,7 +116,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -172,7 +172,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -235,7 +235,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -281,7 +281,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -323,7 +323,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -365,7 +365,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -400,7 +400,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -425,7 +425,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -450,7 +450,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -488,7 +488,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -527,7 +527,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -566,74 +566,69 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -641,11 +636,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -653,44 +648,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -699,31 +694,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -732,7 +727,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -745,19 +740,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -765,15 +760,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -785,11 +780,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -806,15 +801,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -822,76 +817,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -900,35 +895,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -944,48 +939,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -994,118 +989,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1114,15 +1109,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1130,11 +1125,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1143,70 +1138,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1215,85 +1210,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1309,34 +1304,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1345,33 +1340,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1379,11 +1374,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1403,114 +1398,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1526,149 +1521,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1676,72 +1671,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1749,112 +1744,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1899,16 +1894,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1916,7 +1911,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,28 +1923,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1957,54 +1952,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -2016,73 +2011,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2097,7 +2092,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -2105,25 +2100,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2151,80 +2146,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,37 +2234,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2279,31 +2274,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2313,26 +2308,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2342,35 +2337,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2378,11 +2373,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2394,7 +2389,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2418,16 +2413,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2439,7 +2434,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2448,30 +2443,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2479,23 +2474,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2507,55 +2502,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2564,85 +2559,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2656,94 +2651,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2751,42 +2746,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2796,23 +2791,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2825,7 +2815,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2835,31 +2825,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2867,60 +2857,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2932,123 +2922,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -3079,15 +3069,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -3170,31 +3160,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3213,19 +3203,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -3248,11 +3238,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3261,91 +3251,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3353,7 +3343,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3361,19 +3351,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3396,7 +3386,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3404,108 +3394,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3519,43 +3509,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3565,51 +3555,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3619,107 +3609,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3735,24 +3725,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3768,263 +3758,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4033,53 +4023,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4091,57 +4081,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4150,52 +4140,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4215,7 +4205,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4225,125 +4215,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4352,88 +4342,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4443,39 +4429,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4483,23 +4469,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4507,24 +4493,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4532,45 +4518,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4578,22 +4564,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4608,16 +4594,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4625,91 +4611,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4718,19 +4704,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4739,11 +4725,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4769,7 +4755,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4786,11 +4772,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4799,11 +4785,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4812,11 +4798,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4825,11 +4811,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4838,11 +4824,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4851,11 +4837,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4864,15 +4850,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4881,11 +4867,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4894,11 +4880,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4907,11 +4893,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4920,11 +4906,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4933,23 +4919,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4961,19 +4947,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4985,7 +4971,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4997,7 +4983,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5009,71 +4995,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5081,114 +5067,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5197,137 +5183,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5335,15 +5321,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5351,7 +5337,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5359,17 +5345,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5388,32 +5374,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5429,23 +5415,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5460,69 +5446,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5532,69 +5518,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5604,12 +5590,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5619,11 +5605,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5631,7 +5617,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5639,100 +5625,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5741,7 +5727,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5750,52 +5736,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5804,7 +5790,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5818,9 +5804,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5832,76 +5818,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5909,81 +5895,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6007,11 +5993,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6019,8 +6005,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -6028,7 +6014,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6036,24 +6022,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6061,11 +6047,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6074,24 +6060,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6099,220 +6085,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6328,11 +6314,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6340,60 +6326,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6401,7 +6387,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6413,68 +6399,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6512,32 +6498,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6546,13 +6532,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6561,7 +6547,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6569,7 +6555,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6584,7 +6570,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6610,7 +6596,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6624,7 +6610,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6633,13 +6619,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6662,13 +6648,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6695,74 +6681,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6770,24 +6756,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6795,16 +6781,16 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -44,7 +44,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -76,7 +76,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -102,7 +102,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -117,7 +117,7 @@ msgstr ""
 "# # # um exemplo seria:\n"
 "# # # Descrição: Minha imagem personalizada"
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -169,7 +169,7 @@ msgstr ""
 "###\n"
 "### Observe que o nome é exibido mas não pode ser modificado"
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -231,7 +231,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -276,7 +276,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -317,7 +317,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -358,7 +358,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -390,7 +390,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -416,7 +416,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -442,7 +442,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -479,7 +479,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -518,7 +518,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado"
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -554,7 +554,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -562,71 +562,66 @@ msgstr ""
 "### Essa é uma representação yaml do membro do cluster.\n"
 "### Qualquer linha iniciando em '# será ignorada"
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA nó: %v)"
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, fuzzy, c-format
 msgid "%s (%d available)"
 msgstr "%s (%d mais)"
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr "%v (interrompa mais duas vezes para forçar)"
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr "(nenhum)"
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Nível %d (tipo: %s): %s"
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partição %d"
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 #, fuzzy
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 #, fuzzy
 msgid "--console can't be used with --all"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 #, fuzzy
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
@@ -636,12 +631,12 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh só pode ser usado com containers"
@@ -651,47 +646,47 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--project cannot be used with the query command"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 #, fuzzy
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -700,31 +695,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -734,7 +729,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -747,20 +742,20 @@ msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 msgid "Action (defaults to GET)"
 msgstr "Ação (padrão para o GET)"
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -769,15 +764,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr "Adicionar novo aliases"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr "Adicionar novos servidores remoto"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -789,12 +784,12 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 #, fuzzy
 msgid "Add new trusted client"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -811,15 +806,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "Adicionar perfis aos containers"
@@ -829,79 +824,79 @@ msgstr "Adicionar perfis aos containers"
 msgid "Add roles to a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Criado: %s"
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr "Alias %s já existe"
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr "Alias %s não existe"
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr "Nome do alias ausente"
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, fuzzy, c-format
 msgid "Aliases already exists: %s"
 msgstr "Alias %s já existe"
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -910,40 +905,40 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Atribuir conjuntos de perfis aos containers"
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Atribuir conjuntos de perfis aos containers"
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 #, fuzzy
 msgid "Attach network interfaces to instances"
 msgstr "Anexar interfaces de rede aos containers"
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 #, fuzzy
 msgid "Attach new network interfaces to instances"
 msgstr "Anexar uma nova interface de rede aos containers"
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -960,49 +955,49 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 #, fuzzy
 msgid "Available projects:"
 msgstr "Criar projetos"
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr "IMAGEM BASE"
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -1011,119 +1006,119 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr "Marca: %v"
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr "CANCELÁVEL"
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "Utilização do CPU:"
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr "Utilização do CPU (em segundos)"
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr "Utilização do CPU:"
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, fuzzy, c-format
 msgid "CPUs (%s):"
 msgstr "CPUs:"
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr "CRIADO"
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr "CRIADO EM"
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "Versão CUDA: %v"
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr "Em cache: %s"
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 #, fuzzy
 msgid "Caches:"
 msgstr "Em cache: %s"
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1132,15 +1127,15 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr "Não é possível especificar --fast com --columns"
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 #, fuzzy
 msgid "Can't specify --project with --all-projects"
 msgstr "Não é possível especificar --fast com --columns"
@@ -1149,11 +1144,11 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1162,70 +1157,70 @@ msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr "Cartão %d:"
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1235,85 +1230,85 @@ msgstr "Certificado do cliente armazenado no servidor: "
 msgid "Client version: %s\n"
 msgstr "Versão do cliente: %s\n"
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr "Colunas"
 
@@ -1334,38 +1329,38 @@ msgstr ""
 "abaixo.\n"
 "Para obter ajuda com qualquer um desses, simplesmente use-os com --help."
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 #, fuzzy
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 #, fuzzy
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
@@ -1374,33 +1369,33 @@ msgstr "Erro de análise de configuração: %s"
 msgid "Console log:"
 msgstr "Log de Console:"
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr "Aliases de cópia da fonte"
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr "Copiar imagens entre servidores"
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1408,12 +1403,12 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 #, fuzzy
 msgid "Copy instances within or in between LXD servers"
 msgstr "Copiar imagens entre servidores"
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1433,116 +1428,116 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1563,161 +1558,161 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 #, fuzzy
 msgid "Create new instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 #, fuzzy
 msgid "Create new network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr "Criar novas redes"
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr "Criar perfis"
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr "Criar projetos"
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr "Criando %s"
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Criando %s"
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 #, fuzzy
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 #, fuzzy
 msgid "Delete instance file templates"
 msgstr "Editar templates de arquivo do container"
@@ -1727,79 +1722,79 @@ msgstr "Editar templates de arquivo do container"
 msgid "Delete instances and snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 #, fuzzy
 msgid "Delete network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 #, fuzzy
 msgid "Delete network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 #, fuzzy
 msgid "Delete network peerings"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr "Apagar projetos"
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Apagar projetos"
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1807,115 +1802,115 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Desconectar interfaces de rede dos containers"
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
@@ -1961,16 +1956,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
@@ -1978,7 +1973,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1990,30 +1985,30 @@ msgstr "Desabilitar alocação de pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Desabilitar stdin (ler de /dev/null)"
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Uso de disco:"
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr "Uso de disco:"
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 #, fuzzy
 msgid "Disk:"
 msgstr "Uso de disco:"
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 #, fuzzy
 msgid "Disks:"
 msgstr "Uso de disco:"
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2021,57 +2016,57 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr "EFÊMERO"
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DE VALIDADE"
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 #, fuzzy
 msgid "Edit instance file templates"
 msgstr "Editar templates de arquivo do container"
@@ -2086,82 +2081,82 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 #, fuzzy
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2176,7 +2171,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -2184,26 +2179,26 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -2231,80 +2226,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2319,37 +2314,37 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2359,31 +2354,31 @@ msgstr "Aceitar certificado"
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2393,26 +2388,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2422,35 +2417,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2458,11 +2453,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr "Forçar alocação de pseudo-terminal"
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Ignorar o estado do container"
@@ -2475,7 +2470,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2499,16 +2494,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2515,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2529,30 +2524,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2560,24 +2555,24 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -2592,63 +2587,63 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for instance or server configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 #, fuzzy
 msgid "Get values for network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2657,85 +2652,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr "ID"
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr "IPV6"
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2749,96 +2744,96 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 #, fuzzy
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2846,42 +2841,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2891,23 +2886,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr "Editar arquivos no container"
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2920,7 +2910,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -2930,32 +2920,32 @@ msgstr "Editar arquivos no container"
 msgid "Invalid key=value configuration: %s"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2963,61 +2953,61 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -3029,128 +3019,128 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Criado: %s"
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Arquitetura: %v"
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -3181,16 +3171,16 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 #, fuzzy
 msgid "List instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -3273,31 +3263,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3316,19 +3306,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -3351,11 +3341,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3364,93 +3354,93 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 #, fuzzy
 msgid "Lower device"
 msgstr "Editar arquivos no container"
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 #, fuzzy
 msgid "Lower devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3459,7 +3449,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr "Nome de membro do cluster"
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3468,20 +3458,20 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3505,7 +3495,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 #, fuzzy
 msgid "Manage instance file templates"
 msgstr "Editar templates de arquivo do container"
@@ -3515,122 +3505,122 @@ msgstr "Editar templates de arquivo do container"
 msgid "Manage instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 #, fuzzy
 msgid "Manage network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Criar novas redes"
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Criar novas redes"
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Criar novas redes"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Criar novas redes"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Editar arquivos no container"
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Copiar perfis"
@@ -3645,43 +3635,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3691,56 +3681,56 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 #, fuzzy
 msgid "Missing key name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nome de membro do cluster"
@@ -3751,113 +3741,113 @@ msgstr "Nome de membro do cluster"
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 #, fuzzy
 msgid "Missing target network"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3873,25 +3863,25 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3907,263 +3897,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4172,53 +4162,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4230,57 +4220,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4289,53 +4279,53 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4355,7 +4345,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4365,131 +4355,131 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 #, fuzzy
 msgid "Profiles:"
 msgstr "Copiar perfis"
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 #, fuzzy
 msgid "Profiles: "
 msgstr "Copiar perfis"
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4498,88 +4488,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4589,43 +4575,43 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Adicionar perfis aos containers"
@@ -4634,26 +4620,26 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4662,26 +4648,26 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 #, fuzzy
 msgid "Remove trusted client"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4689,46 +4675,46 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 #, fuzzy
 msgid "Rename network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4736,23 +4722,23 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 #, fuzzy
 msgid "Restart instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nome de membro do cluster"
@@ -4773,16 +4759,16 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4790,93 +4776,93 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Criado: %s"
@@ -4885,19 +4871,19 @@ msgstr "Criado: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4906,12 +4892,12 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4938,7 +4924,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
@@ -4957,12 +4943,12 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4971,11 +4957,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4984,12 +4970,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4998,12 +4984,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5012,12 +4998,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5026,12 +5012,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5040,16 +5026,16 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5058,12 +5044,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5072,12 +5058,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5086,11 +5072,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5099,11 +5085,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5112,23 +5098,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5140,21 +5126,21 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 #, fuzzy
 msgid "Show content of instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -5167,7 +5153,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Adicionar dispositivos aos containers ou perfis"
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -5181,7 +5167,7 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Show instance or server configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 #, fuzzy
 msgid "Show instance or server information"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5194,82 +5180,82 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 #, fuzzy
 msgid "Show network ACL configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5277,116 +5263,116 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5395,140 +5381,140 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Clustering ativado"
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 #, fuzzy
 msgid "The --mode flag can't be used with --storage"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 #, fuzzy
 msgid "The --mode flag can't be used with --target-project"
 msgstr "--refresh só pode ser usado com containers"
@@ -5537,17 +5523,17 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 #, fuzzy
 msgid "The --storage flag can't be used with --target"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5555,7 +5541,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5563,17 +5549,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nome de membro do cluster"
@@ -5592,32 +5578,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
@@ -5634,23 +5620,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5665,69 +5651,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Aceitar certificado"
@@ -5738,70 +5724,70 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Adicionar novos servidores remoto"
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5811,12 +5797,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5826,12 +5812,12 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
@@ -5841,7 +5827,7 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
@@ -5851,113 +5837,113 @@ msgstr "Editar propriedades da imagem"
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 #, fuzzy
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5966,7 +5952,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5975,52 +5961,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6029,7 +6015,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6043,9 +6029,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6057,85 +6043,85 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 #, fuzzy
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 #, fuzzy
 msgid "[<remote>:] [<cert>]"
 msgstr "Criar perfis"
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Criar perfis"
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Criar perfis"
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "Editar templates de arquivo do container"
@@ -6144,90 +6130,90 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Criar perfis"
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr "Criar perfis"
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Criar perfis"
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Criar perfis"
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6251,11 +6237,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6264,8 +6250,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 #, fuzzy
 msgid "[<remote>:]<instance> <template>"
 msgstr "Editar templates de arquivo do container"
@@ -6274,7 +6260,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6282,24 +6268,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -6308,11 +6294,11 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6321,27 +6307,27 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6350,243 +6336,243 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "Criar perfis"
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr "Criar perfis"
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "Criar perfis"
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr "Criar perfis"
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "Criar perfis"
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "Criar perfis"
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Criar perfis"
@@ -6603,11 +6589,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6615,67 +6601,67 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Criar projetos"
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Criar perfis"
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "Criar perfis"
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"
@@ -6684,7 +6670,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6696,70 +6682,70 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 #, fuzzy
 msgid "[[<remote>:]<name>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6797,32 +6783,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6831,13 +6817,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6846,7 +6832,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6854,7 +6840,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6869,7 +6855,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6895,7 +6881,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6909,7 +6895,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6918,13 +6904,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6947,13 +6933,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6980,74 +6966,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7055,24 +7041,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -7080,18 +7066,22 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr "sim"
+
+#, c-format
+#~ msgid "%v (interrupt two more times to force)"
+#~ msgstr "%v (interrompa mais duas vezes para forçar)"
 
 #, fuzzy
 #~ msgid "[<remote>:] <fingerprint>"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,11 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -47,7 +47,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -78,7 +78,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -106,7 +106,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -121,7 +121,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -173,7 +173,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -232,7 +232,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -277,7 +277,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -318,7 +318,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -359,7 +359,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -394,7 +394,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -422,7 +422,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -450,7 +450,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -487,7 +487,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -526,7 +526,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -565,74 +565,69 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr "(пусто)"
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Порт %d (%s)"
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -640,11 +635,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -652,41 +647,41 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 #, fuzzy
 msgid "<alias>"
 msgstr "Псевдонимы:"
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -694,7 +689,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -703,32 +698,32 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 #, fuzzy
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -737,7 +732,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -750,20 +745,20 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -772,16 +767,16 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 #, fuzzy
 msgid "Add new aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -793,11 +788,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -814,15 +809,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -831,78 +826,78 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr "Архитектура: %v"
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -911,37 +906,37 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -957,49 +952,49 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 #, fuzzy
 msgid "Available projects:"
 msgstr "Доступные команды:"
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -1008,120 +1003,120 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr " Использование ЦП:"
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 #, fuzzy
 msgid "CREATED"
 msgstr "СОЗДАН"
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr "СОЗДАН"
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1130,15 +1125,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1146,11 +1141,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1159,70 +1154,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1232,85 +1227,85 @@ msgstr "Сертификат клиента хранится на сервере
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr " Использование сети:"
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -1326,34 +1321,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1362,33 +1357,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr "Копировать псевдонимы из источника"
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1396,11 +1391,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1420,118 +1415,118 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
-msgstr ""
-
-#: lxc/init.go:59
-#, fuzzy
-msgid "Create a virtual machine"
-msgstr "Копирование образа: %s"
-
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
-msgid "Create aliases for existing images"
 msgstr ""
 
 #: lxc/init.go:58
 #, fuzzy
+msgid "Create a virtual machine"
+msgstr "Копирование образа: %s"
+
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
+msgid "Create aliases for existing images"
+msgstr ""
+
+#: lxc/init.go:57
+#, fuzzy
 msgid "Create an empty instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1548,163 +1543,163 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 #, fuzzy
 msgid "Create instances from images"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 #, fuzzy
 msgid "Create new instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 #, fuzzy
 msgid "Delete instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1714,78 +1709,78 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete instances and snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1793,114 +1788,114 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1945,16 +1940,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1962,7 +1957,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1974,32 +1969,32 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Использование диска:"
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 #, fuzzy
 msgid "Disk:"
 msgstr " Использование диска:"
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 #, fuzzy
 msgid "Disks:"
 msgstr " Использование диска:"
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2007,54 +2002,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 #, fuzzy
 msgid "Edit instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2068,78 +2063,78 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2154,7 +2149,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -2162,21 +2157,21 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, fuzzy, c-format
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2184,7 +2179,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -2212,85 +2207,85 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 #, fuzzy
 msgid "Export and download images"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 #, fuzzy
 msgid "Export instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2305,37 +2300,37 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2345,31 +2340,31 @@ msgstr "Принять сертификат"
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2379,26 +2374,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2408,35 +2403,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Принять сертификат"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2444,11 +2439,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2461,7 +2456,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2485,16 +2480,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2501,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2515,30 +2510,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2546,23 +2541,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Копирование образа: %s"
@@ -2575,61 +2570,61 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2638,86 +2633,86 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 #, fuzzy
 msgid "Host interface"
 msgstr "Псевдонимы:"
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2731,98 +2726,98 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Копирование образа: %s"
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 #, fuzzy
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2830,44 +2825,44 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 #, fuzzy
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 #, fuzzy
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2877,23 +2872,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2906,7 +2896,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -2916,32 +2906,32 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid key=value configuration: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2949,61 +2939,61 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -3015,130 +3005,130 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Архитектура: %s"
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 #, fuzzy
 msgid "List aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 #, fuzzy
 msgid "List all warnings"
 msgstr "Псевдонимы:"
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -3170,17 +3160,17 @@ msgstr ""
 msgid "List instance devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 #, fuzzy
 msgid "List instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, fuzzy
 msgid "List instances"
 msgstr "Псевдонимы:"
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -3263,34 +3253,34 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3309,20 +3299,20 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 #, fuzzy
 msgid "List warnings"
 msgstr "Псевдонимы:"
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -3345,11 +3335,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3358,94 +3348,94 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 #, fuzzy
 msgid "Lower device"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 #, fuzzy
 msgid "Lower devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3454,7 +3444,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr "Копирование образа: %s"
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3463,19 +3453,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3498,7 +3488,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 #, fuzzy
 msgid "Manage instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3508,125 +3498,125 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Manage instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 #, fuzzy
 msgid "Manage storage pools and volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Копирование образа: %s"
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3640,45 +3630,45 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 #, fuzzy
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3688,56 +3678,56 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 #, fuzzy
 msgid "Missing key name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Имя контейнера: %s"
@@ -3748,115 +3738,115 @@ msgstr "Имя контейнера: %s"
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 #, fuzzy
 msgid "Missing target network"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3872,25 +3862,25 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3906,267 +3896,267 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 #, fuzzy
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4175,54 +4165,54 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4234,57 +4224,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4293,53 +4283,53 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4359,7 +4349,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4369,125 +4359,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4496,90 +4486,86 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4589,43 +4575,43 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Копирование образа: %s"
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4634,24 +4620,24 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4660,24 +4646,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4686,47 +4672,47 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4734,23 +4720,23 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 #, fuzzy
 msgid "Restart instances"
 msgstr "Псевдонимы:"
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Копирование образа: %s"
@@ -4767,17 +4753,17 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4785,93 +4771,93 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Авто-обновление: %s"
@@ -4880,19 +4866,19 @@ msgstr "Авто-обновление: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4901,12 +4887,12 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,7 +4918,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4949,11 +4935,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4962,11 +4948,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4975,12 +4961,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4989,12 +4975,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5003,12 +4989,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -5017,12 +5003,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5031,16 +5017,16 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5049,11 +5035,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5062,12 +5048,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5076,11 +5062,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -5089,11 +5075,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5102,23 +5088,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5130,21 +5116,21 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 #, fuzzy
 msgid "Show content of instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -5156,7 +5142,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -5169,7 +5155,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5181,81 +5167,81 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5263,119 +5249,119 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 #, fuzzy
 msgid "State"
 msgstr "Авто-обновление: %s"
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 #, fuzzy
 msgid "Stop instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 #, fuzzy
 msgid "Stopping instance failed!"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5385,138 +5371,138 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Stopping the instance failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr " Использование сети:"
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5524,15 +5510,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5540,7 +5526,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5548,17 +5534,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Копирование образа: %s"
@@ -5577,32 +5563,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5618,23 +5604,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5649,69 +5635,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Принять сертификат"
@@ -5722,69 +5708,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5794,12 +5780,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5809,12 +5795,12 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5822,7 +5808,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5830,111 +5816,111 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Принять сертификат"
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 #, fuzzy
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5943,7 +5929,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5952,52 +5938,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6006,7 +5992,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6020,9 +6006,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6034,15 +6020,15 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -6050,7 +6036,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -6058,11 +6044,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -6070,7 +6056,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 #, fuzzy
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
@@ -6078,7 +6064,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -6086,7 +6072,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -6094,7 +6080,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 #, fuzzy
 msgid "[<remote>:] [<cert>]"
 msgstr ""
@@ -6102,7 +6088,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -6110,7 +6096,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
@@ -6118,8 +6104,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -6127,7 +6113,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -6135,7 +6121,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -6143,7 +6129,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -6151,7 +6137,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -6159,7 +6145,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -6175,7 +6161,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -6183,7 +6169,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -6191,7 +6177,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -6199,7 +6185,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -6207,7 +6193,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -6215,7 +6201,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
@@ -6223,7 +6209,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -6231,7 +6217,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -6239,7 +6225,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
@@ -6247,8 +6233,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6256,7 +6242,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -6264,7 +6250,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -6272,7 +6258,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -6280,7 +6266,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -6288,7 +6274,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -6296,7 +6282,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
@@ -6304,7 +6290,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -6312,7 +6298,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -6321,7 +6307,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6369,7 +6355,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -6377,7 +6363,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -6393,8 +6379,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 #, fuzzy
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
@@ -6410,7 +6396,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
@@ -6426,7 +6412,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 #, fuzzy
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
@@ -6434,7 +6420,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -6442,7 +6428,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -6450,7 +6436,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -6459,7 +6445,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -6475,7 +6461,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
@@ -6483,7 +6469,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -6500,8 +6486,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -6509,7 +6495,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -6517,7 +6503,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -6525,7 +6511,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -6533,7 +6519,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -6549,9 +6535,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6559,7 +6545,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -6567,7 +6553,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
@@ -6575,7 +6561,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -6583,7 +6569,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -6591,9 +6577,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6601,7 +6587,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -6609,7 +6595,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -6619,8 +6605,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -6628,7 +6614,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -6636,7 +6622,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -6646,13 +6632,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -6660,7 +6646,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
@@ -6668,7 +6654,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -6676,7 +6662,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
@@ -6684,7 +6670,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -6692,7 +6678,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
@@ -6702,7 +6688,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -6710,7 +6696,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -6718,7 +6704,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -6726,7 +6712,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -6734,7 +6720,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -6742,7 +6728,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr ""
@@ -6750,8 +6736,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -6759,7 +6745,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -6767,8 +6753,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -6776,9 +6762,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -6786,7 +6772,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -6794,7 +6780,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -6802,7 +6788,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
@@ -6810,7 +6796,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -6818,7 +6804,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -6826,7 +6812,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -6836,7 +6822,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -6844,7 +6830,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -6852,7 +6838,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
@@ -6860,7 +6846,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
@@ -6868,7 +6854,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
@@ -6876,7 +6862,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -6884,7 +6870,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -6892,7 +6878,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -6900,7 +6886,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -6908,8 +6894,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -6917,7 +6903,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
@@ -6925,7 +6911,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -6933,7 +6919,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -6941,7 +6927,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -6949,8 +6935,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -6982,7 +6968,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -6990,7 +6976,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -7006,7 +6992,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -7014,7 +7000,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -7022,8 +7008,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -7031,7 +7017,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -7039,7 +7025,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -7047,7 +7033,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -7055,7 +7041,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -7063,7 +7049,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -7071,7 +7057,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -7079,7 +7065,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -7087,7 +7073,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -7095,7 +7081,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -7103,7 +7089,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -7111,7 +7097,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -7127,7 +7113,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr ""
@@ -7151,7 +7137,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -7159,7 +7145,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 #, fuzzy
 msgid "[[<remote>:]<name>]"
 msgstr ""
@@ -7167,60 +7153,60 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7258,32 +7244,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7292,13 +7278,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7307,7 +7293,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -7315,7 +7301,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -7330,7 +7316,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7356,7 +7342,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -7370,7 +7356,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -7379,13 +7365,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7408,13 +7394,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7441,74 +7427,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7516,24 +7502,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -7541,16 +7527,16 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr "да"
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -16,11 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -72,7 +72,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -99,7 +99,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -161,7 +161,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -209,7 +209,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -240,7 +240,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -274,7 +274,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -295,7 +295,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -316,74 +316,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -391,11 +386,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -403,44 +398,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -449,31 +444,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -482,7 +477,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -495,19 +490,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -515,15 +510,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -535,11 +530,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -556,15 +551,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -572,76 +567,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -650,35 +645,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -694,48 +689,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -744,118 +739,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -864,15 +859,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -880,11 +875,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -893,70 +888,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -965,85 +960,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1059,34 +1054,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1095,33 +1090,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1129,11 +1124,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1153,114 +1148,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1276,149 +1271,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1426,72 +1421,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1499,112 +1494,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1649,16 +1644,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1666,7 +1661,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1678,28 +1673,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1707,54 +1702,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1766,73 +1761,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1847,7 +1842,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1855,25 +1850,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1901,80 +1896,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1989,37 +1984,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2029,31 +2024,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2063,26 +2058,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2092,35 +2087,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2128,11 +2123,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2144,7 +2139,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2168,16 +2163,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2189,7 +2184,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2198,30 +2193,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2229,23 +2224,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2257,55 +2252,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2314,85 +2309,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2406,94 +2401,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2501,42 +2496,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2546,23 +2541,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2575,7 +2565,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2585,31 +2575,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2617,60 +2607,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2682,123 +2672,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2829,15 +2819,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2920,31 +2910,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2963,19 +2953,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2998,11 +2988,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3011,91 +3001,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3103,7 +3093,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3111,19 +3101,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3146,7 +3136,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3154,108 +3144,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3269,43 +3259,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3315,51 +3305,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3369,107 +3359,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3485,24 +3475,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3518,263 +3508,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3783,53 +3773,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3841,57 +3831,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3900,52 +3890,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3965,7 +3955,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3975,125 +3965,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4102,88 +4092,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4193,39 +4179,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4233,23 +4219,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4257,24 +4243,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4282,45 +4268,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4328,22 +4314,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4358,16 +4344,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4375,91 +4361,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4468,19 +4454,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4489,11 +4475,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4519,7 +4505,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4536,11 +4522,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4549,11 +4535,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4562,11 +4548,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4575,11 +4561,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4588,11 +4574,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4601,11 +4587,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4614,15 +4600,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4631,11 +4617,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4644,11 +4630,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4657,11 +4643,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4670,11 +4656,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4683,23 +4669,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4711,19 +4697,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4735,7 +4721,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4747,7 +4733,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4759,71 +4745,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4831,114 +4817,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4947,137 +4933,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5085,15 +5071,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5101,7 +5087,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5109,17 +5095,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5138,32 +5124,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5179,23 +5165,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5210,69 +5196,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5282,69 +5268,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5354,12 +5340,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5369,11 +5355,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5381,7 +5367,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5389,100 +5375,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5491,7 +5477,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5500,52 +5486,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5554,7 +5540,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5568,9 +5554,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5582,76 +5568,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5659,81 +5645,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5757,11 +5743,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5769,8 +5755,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5778,7 +5764,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5786,24 +5772,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5811,11 +5797,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5824,24 +5810,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5849,220 +5835,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6078,11 +6064,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6090,60 +6076,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6151,7 +6137,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6163,68 +6149,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6262,32 +6248,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6296,13 +6282,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6311,7 +6297,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6319,7 +6305,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6334,7 +6320,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6360,7 +6346,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6374,7 +6360,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6383,13 +6369,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6412,13 +6398,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6445,74 +6431,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6520,24 +6506,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6545,15 +6531,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,11 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -72,7 +72,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -99,7 +99,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -161,7 +161,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -209,7 +209,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -240,7 +240,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -274,7 +274,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -295,7 +295,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -316,74 +316,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -391,11 +386,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -403,44 +398,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -449,31 +444,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -482,7 +477,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -495,19 +490,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -515,15 +510,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -535,11 +530,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -556,15 +551,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -572,76 +567,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -650,35 +645,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -694,48 +689,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -744,118 +739,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -864,15 +859,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -880,11 +875,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -893,70 +888,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -965,85 +960,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1059,34 +1054,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1095,33 +1090,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1129,11 +1124,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1153,114 +1148,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1276,149 +1271,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1426,72 +1421,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1499,112 +1494,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1649,16 +1644,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1666,7 +1661,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1678,28 +1673,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1707,54 +1702,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1766,73 +1761,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1847,7 +1842,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1855,25 +1850,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1901,80 +1896,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1989,37 +1984,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2029,31 +2024,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2063,26 +2058,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2092,35 +2087,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2128,11 +2123,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2144,7 +2139,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2168,16 +2163,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2189,7 +2184,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2198,30 +2193,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2229,23 +2224,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2257,55 +2252,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2314,85 +2309,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2406,94 +2401,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2501,42 +2496,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2546,23 +2541,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2575,7 +2565,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2585,31 +2575,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2617,60 +2607,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2682,123 +2672,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2829,15 +2819,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2920,31 +2910,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2963,19 +2953,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2998,11 +2988,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3011,91 +3001,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3103,7 +3093,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3111,19 +3101,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3146,7 +3136,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3154,108 +3144,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3269,43 +3259,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3315,51 +3305,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3369,107 +3359,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3485,24 +3475,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3518,263 +3508,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3783,53 +3773,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3841,57 +3831,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3900,52 +3890,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3965,7 +3955,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3975,125 +3965,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4102,88 +4092,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4193,39 +4179,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4233,23 +4219,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4257,24 +4243,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4282,45 +4268,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4328,22 +4314,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4358,16 +4344,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4375,91 +4361,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4468,19 +4454,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4489,11 +4475,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4519,7 +4505,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4536,11 +4522,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4549,11 +4535,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4562,11 +4548,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4575,11 +4561,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4588,11 +4574,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4601,11 +4587,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4614,15 +4600,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4631,11 +4617,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4644,11 +4630,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4657,11 +4643,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4670,11 +4656,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4683,23 +4669,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4711,19 +4697,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4735,7 +4721,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4747,7 +4733,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4759,71 +4745,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4831,114 +4817,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4947,137 +4933,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5085,15 +5071,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5101,7 +5087,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5109,17 +5095,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5138,32 +5124,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5179,23 +5165,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5210,69 +5196,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5282,69 +5268,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5354,12 +5340,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5369,11 +5355,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5381,7 +5367,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5389,100 +5375,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5491,7 +5477,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5500,52 +5486,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5554,7 +5540,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5568,9 +5554,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5582,76 +5568,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5659,81 +5645,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5757,11 +5743,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5769,8 +5755,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5778,7 +5764,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5786,24 +5772,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5811,11 +5797,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5824,24 +5810,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5849,220 +5835,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6078,11 +6064,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6090,60 +6076,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6151,7 +6137,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6163,68 +6149,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6262,32 +6248,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6296,13 +6282,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6311,7 +6297,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6319,7 +6305,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6334,7 +6320,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6360,7 +6346,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6374,7 +6360,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6383,13 +6369,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6412,13 +6398,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6445,74 +6431,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6520,24 +6506,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6545,15 +6531,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -29,7 +29,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -68,7 +68,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -95,7 +95,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -129,7 +129,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -157,7 +157,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -205,7 +205,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -222,7 +222,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -236,7 +236,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -250,7 +250,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -270,7 +270,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -291,7 +291,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -312,74 +312,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -387,11 +382,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -399,44 +394,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -445,31 +440,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -478,7 +473,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -491,19 +486,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -511,15 +506,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -531,11 +526,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -552,15 +547,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -568,76 +563,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -646,35 +641,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -690,48 +685,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -740,118 +735,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -860,15 +855,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -876,11 +871,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -889,70 +884,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -961,85 +956,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1055,34 +1050,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1091,33 +1086,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1125,11 +1120,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1149,114 +1144,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1272,149 +1267,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1422,72 +1417,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1495,112 +1490,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1645,16 +1640,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1662,7 +1657,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1674,28 +1669,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1703,54 +1698,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1762,73 +1757,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1843,7 +1838,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1851,25 +1846,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1897,80 +1892,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1985,37 +1980,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2025,31 +2020,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2059,26 +2054,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2088,35 +2083,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2124,11 +2119,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2140,7 +2135,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2164,16 +2159,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2185,7 +2180,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2194,30 +2189,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2225,23 +2220,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2253,55 +2248,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2310,85 +2305,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2402,94 +2397,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2497,42 +2492,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2542,23 +2537,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2571,7 +2561,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2581,31 +2571,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2613,60 +2603,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2678,123 +2668,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2825,15 +2815,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2916,31 +2906,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2959,19 +2949,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2994,11 +2984,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3007,91 +2997,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3099,7 +3089,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3107,19 +3097,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3142,7 +3132,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3150,108 +3140,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3265,43 +3255,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3311,51 +3301,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3365,107 +3355,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3481,24 +3471,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3514,263 +3504,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3779,53 +3769,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3837,57 +3827,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3896,52 +3886,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3961,7 +3951,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3971,125 +3961,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4098,88 +4088,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4189,39 +4175,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4229,23 +4215,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4253,24 +4239,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4278,45 +4264,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4324,22 +4310,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4354,16 +4340,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4371,91 +4357,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4464,19 +4450,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4485,11 +4471,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4515,7 +4501,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4532,11 +4518,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4545,11 +4531,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4558,11 +4544,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4571,11 +4557,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4584,11 +4570,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4597,11 +4583,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4610,15 +4596,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4627,11 +4613,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4640,11 +4626,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4653,11 +4639,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4666,11 +4652,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4679,23 +4665,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4707,19 +4693,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4731,7 +4717,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4743,7 +4729,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4755,71 +4741,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4827,114 +4813,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4943,137 +4929,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5081,15 +5067,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5097,7 +5083,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5105,17 +5091,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5134,32 +5120,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5175,23 +5161,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5206,69 +5192,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5278,69 +5264,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5350,12 +5336,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5365,11 +5351,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5377,7 +5363,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5385,100 +5371,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5487,7 +5473,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5496,52 +5482,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5550,7 +5536,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5564,9 +5550,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5578,76 +5564,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5655,81 +5641,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5753,11 +5739,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5765,8 +5751,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5774,7 +5760,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5782,24 +5768,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5807,11 +5793,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5820,24 +5806,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5845,220 +5831,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6074,11 +6060,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6086,60 +6072,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6147,7 +6133,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6159,68 +6145,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6258,32 +6244,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6292,13 +6278,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6307,7 +6293,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6315,7 +6301,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6330,7 +6316,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6356,7 +6342,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6370,7 +6356,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6379,13 +6365,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6408,13 +6394,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6441,74 +6427,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,24 +6502,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6541,15 +6527,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n >= 2 && (n < 11 || n > 99);\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -16,11 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -72,7 +72,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -99,7 +99,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -161,7 +161,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -209,7 +209,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -240,7 +240,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -274,7 +274,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -295,7 +295,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -316,74 +316,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -391,11 +386,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -403,44 +398,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -449,31 +444,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -482,7 +477,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -495,19 +490,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -515,15 +510,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -535,11 +530,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -556,15 +551,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -572,76 +567,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -650,35 +645,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -694,48 +689,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -744,118 +739,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -864,15 +859,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -880,11 +875,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -893,70 +888,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -965,85 +960,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1059,34 +1054,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1095,33 +1090,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1129,11 +1124,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1153,114 +1148,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1276,149 +1271,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1426,72 +1421,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1499,112 +1494,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1649,16 +1644,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1666,7 +1661,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1678,28 +1673,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1707,54 +1702,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1766,73 +1761,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1847,7 +1842,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1855,25 +1850,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1901,80 +1896,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1989,37 +1984,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2029,31 +2024,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2063,26 +2058,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2092,35 +2087,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2128,11 +2123,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2144,7 +2139,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2168,16 +2163,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2189,7 +2184,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2198,30 +2193,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2229,23 +2224,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2257,55 +2252,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2314,85 +2309,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2406,94 +2401,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2501,42 +2496,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2546,23 +2541,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2575,7 +2565,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2585,31 +2575,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2617,60 +2607,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2682,123 +2672,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2829,15 +2819,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2920,31 +2910,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2963,19 +2953,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2998,11 +2988,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3011,91 +3001,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3103,7 +3093,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3111,19 +3101,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3146,7 +3136,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3154,108 +3144,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3269,43 +3259,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3315,51 +3305,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3369,107 +3359,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3485,24 +3475,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3518,263 +3508,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3783,53 +3773,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3841,57 +3831,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3900,52 +3890,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3965,7 +3955,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3975,125 +3965,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4102,88 +4092,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4193,39 +4179,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4233,23 +4219,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4257,24 +4243,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4282,45 +4268,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4328,22 +4314,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4358,16 +4344,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4375,91 +4361,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4468,19 +4454,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4489,11 +4475,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4519,7 +4505,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4536,11 +4522,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4549,11 +4535,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4562,11 +4548,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4575,11 +4561,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4588,11 +4574,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4601,11 +4587,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4614,15 +4600,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4631,11 +4617,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4644,11 +4630,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4657,11 +4643,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4670,11 +4656,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4683,23 +4669,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4711,19 +4697,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4735,7 +4721,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4747,7 +4733,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4759,71 +4745,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4831,114 +4817,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4947,137 +4933,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5085,15 +5071,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5101,7 +5087,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5109,17 +5095,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5138,32 +5124,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5179,23 +5165,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5210,69 +5196,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5282,69 +5268,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5354,12 +5340,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5369,11 +5355,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5381,7 +5367,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5389,100 +5375,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5491,7 +5477,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5500,52 +5486,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5554,7 +5540,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5568,9 +5554,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5582,76 +5568,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5659,81 +5645,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5757,11 +5743,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5769,8 +5755,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5778,7 +5764,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5786,24 +5772,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5811,11 +5797,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5824,24 +5810,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5849,220 +5835,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6078,11 +6064,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6090,60 +6076,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6151,7 +6137,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6163,68 +6149,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6262,32 +6248,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6296,13 +6282,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6311,7 +6297,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6319,7 +6305,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6334,7 +6320,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6360,7 +6346,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6374,7 +6360,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6383,13 +6369,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6412,13 +6398,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6445,74 +6431,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6520,24 +6506,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6545,15 +6531,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -43,7 +43,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -73,7 +73,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -116,7 +116,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -172,7 +172,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -206,7 +206,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -234,7 +234,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -258,7 +258,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -282,7 +282,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -317,7 +317,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -342,7 +342,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -367,7 +367,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -387,7 +387,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -408,7 +408,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -447,74 +447,69 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -522,11 +517,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -534,44 +529,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -580,31 +575,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -626,19 +621,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -646,15 +641,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -666,11 +661,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -687,15 +682,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -703,76 +698,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -781,35 +776,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -825,48 +820,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -875,118 +870,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -995,15 +990,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1011,11 +1006,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1024,70 +1019,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1096,85 +1091,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1190,34 +1185,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1226,33 +1221,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1260,11 +1255,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1284,114 +1279,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1407,149 +1402,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1557,72 +1552,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1630,112 +1625,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1780,16 +1775,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1797,7 +1792,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1809,28 +1804,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1838,54 +1833,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1897,73 +1892,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1978,7 +1973,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1986,25 +1981,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2032,80 +2027,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2120,37 +2115,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2160,31 +2155,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2194,26 +2189,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2223,35 +2218,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2259,11 +2254,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2275,7 +2270,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2299,16 +2294,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2320,7 +2315,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2329,30 +2324,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2360,23 +2355,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2388,55 +2383,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2445,85 +2440,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2537,94 +2532,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2632,42 +2627,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2677,23 +2672,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2706,7 +2696,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2716,31 +2706,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2748,60 +2738,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2813,123 +2803,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2960,15 +2950,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -3051,31 +3041,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3094,19 +3084,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -3129,11 +3119,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3142,91 +3132,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3234,7 +3224,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3242,19 +3232,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3277,7 +3267,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3285,108 +3275,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3400,43 +3390,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3446,51 +3436,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3500,107 +3490,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3616,24 +3606,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3649,263 +3639,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3914,53 +3904,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3972,57 +3962,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4031,52 +4021,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4096,7 +4086,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4106,125 +4096,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4233,88 +4223,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4324,39 +4310,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4364,23 +4350,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4388,24 +4374,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4413,45 +4399,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4459,22 +4445,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4489,16 +4475,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4506,91 +4492,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4599,19 +4585,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4620,11 +4606,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4650,7 +4636,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4667,11 +4653,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4680,11 +4666,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4693,11 +4679,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4706,11 +4692,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4719,11 +4705,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4732,11 +4718,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4745,15 +4731,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4762,11 +4748,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4775,11 +4761,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4788,11 +4774,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4801,11 +4787,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4814,23 +4800,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4842,19 +4828,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4866,7 +4852,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4878,7 +4864,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4890,71 +4876,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4962,114 +4948,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5078,137 +5064,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5216,15 +5202,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5232,7 +5218,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5240,17 +5226,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5269,32 +5255,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5310,23 +5296,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5341,69 +5327,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5413,69 +5399,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5485,12 +5471,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5500,11 +5486,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5512,7 +5498,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5520,100 +5506,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5622,7 +5608,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5631,52 +5617,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5685,7 +5671,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5699,9 +5685,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5713,76 +5699,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5790,81 +5776,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5888,11 +5874,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5900,8 +5886,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5909,7 +5895,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5917,24 +5903,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5942,11 +5928,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5955,24 +5941,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5980,220 +5966,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6209,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6221,60 +6207,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6282,7 +6268,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6294,68 +6280,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6393,32 +6379,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6427,13 +6413,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6442,7 +6428,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6450,7 +6436,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6465,7 +6451,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6491,7 +6477,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6505,7 +6491,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6514,13 +6500,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6543,13 +6529,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6576,74 +6562,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6651,24 +6637,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6676,16 +6662,16 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-06-02 15:29+0200\n"
+"POT-Creation-Date: 2023-06-08 15:47+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
+#: lxc/storage_bucket.go:255 lxc/storage_bucket.go:963
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -32,7 +32,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/storage.go:233
+#: lxc/storage.go:232
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:859
+#: lxc/storage_volume.go:858
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config_trust.go:246
+#: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:350
+#: lxc/cluster_group.go:349
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -98,7 +98,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:379
+#: lxc/image.go:378
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network_acl.go:492
+#: lxc/network_acl.go:491
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:497
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:499
+#: lxc/network_load_balancer.go:498
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_peer.go:488
+#: lxc/network_peer.go:487
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: lxc/network_zone.go:990
+#: lxc/network_zone.go:989
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -239,7 +239,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network_zone.go:435
+#: lxc/network_zone.go:434
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: lxc/network.go:598
+#: lxc/network.go:597
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:426
+#: lxc/profile.go:425
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -294,7 +294,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:234
+#: lxc/project.go:233
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,74 +315,69 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:663
+#: lxc/cluster.go:662
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:320
+#: lxc/info.go:319
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/info.go:162
+#: lxc/info.go:161
 #, c-format
 msgid "%s (%d available)"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:916
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/utils/cancel.go:69
-#, c-format
-msgid "%v (interrupt two more times to force)"
-msgstr ""
-
-#: lxc/file.go:807
+#: lxc/file.go:806
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:130 lxc/profile.go:226
+#: lxc/cluster_group.go:129 lxc/profile.go:225
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:310
+#: lxc/info.go:309
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:197
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:207
+#: lxc/action.go:206
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:354
+#: lxc/action.go:353
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:358
+#: lxc/action.go:357
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:125
+#: lxc/init.go:124
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -390,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:153
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:95
+#: lxc/copy.go:94
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -402,44 +397,44 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:165
+#: lxc/copy.go:164
 msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:152 lxc/config.go:406 lxc/config.go:541 lxc/config.go:688
-#: lxc/info.go:452
+#: lxc/info.go:451
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:195
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:54
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:144
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:878
+#: lxc/remote.go:821 lxc/remote.go:877
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:916
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:457
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:649
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -448,31 +443,31 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:130 lxc/image.go:1054 lxc/image_alias.go:235
+#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1054
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:98
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:816
+#: lxc/storage_bucket.go:815
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:872
+#: lxc/storage_bucket.go:871
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -481,7 +476,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:262 lxc/warning.go:263
+#: lxc/warning.go:261 lxc/warning.go:262
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -494,19 +489,19 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/network_zone.go:1163
+#: lxc/network_zone.go:1162
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:709
+#: lxc/network_load_balancer.go:708
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:708
+#: lxc/network_load_balancer.go:707
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1164
+#: lxc/network_zone.go:1163
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -514,15 +509,15 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:56 lxc/alias.go:57
+#: lxc/alias.go:55 lxc/alias.go:56
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:88
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -534,11 +529,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:87
+#: lxc/config_trust.go:86
 msgid "Add new trusted client"
 msgstr ""
 
-#: lxc/config_trust.go:88
+#: lxc/config_trust.go:87
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -555,15 +550,15 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/network_forward.go:706 lxc/network_forward.go:707
+#: lxc/network_forward.go:705 lxc/network_forward.go:706
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:872 lxc/network_load_balancer.go:873
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:103 lxc/profile.go:104
+#: lxc/profile.go:102 lxc/profile.go:103
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -571,76 +566,76 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:727 lxc/network_acl.go:728
+#: lxc/network_acl.go:726 lxc/network_acl.go:727
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:202
+#: lxc/info.go:201
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:165
+#: lxc/storage_bucket.go:164
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:165
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:80 lxc/alias.go:177
+#: lxc/alias.go:79 lxc/alias.go:176
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:171 lxc/alias.go:222
+#: lxc/alias.go:170 lxc/alias.go:221
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:85 lxc/image_alias.go:132 lxc/image_alias.go:280
+#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
 msgid "Alias name missing"
 msgstr ""
 
-#: lxc/publish.go:243
+#: lxc/publish.go:242
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:975
+#: lxc/image.go:974
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1360
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: lxc/config_trust.go:103
+#: lxc/config_trust.go:102
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:477
+#: lxc/image.go:945 lxc/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1184
+#: lxc/cluster.go:1183
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -649,35 +644,35 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:345
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:79
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:166 lxc/profile.go:167
+#: lxc/profile.go:165 lxc/profile.go:166
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: lxc/network.go:131
+#: lxc/network.go:130
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:216 lxc/network.go:217
+#: lxc/network.go:215 lxc/network.go:216
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:132
+#: lxc/network.go:131
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:163 lxc/storage_volume.go:164
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:238 lxc/storage_volume.go:239
+#: lxc/storage_volume.go:237 lxc/storage_volume.go:238
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -693,48 +688,48 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:548
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:175
+#: lxc/image.go:174
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:985
+#: lxc/image.go:984
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:135
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:561 lxc/list.go:562
+#: lxc/list.go:560 lxc/list.go:561
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:86
+#: lxc/export.go:85
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2159
+#: lxc/storage_volume.go:2158
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:184 lxc/storage_volume.go:2228
+#: lxc/export.go:183 lxc/storage_volume.go:2227
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1292
+#: lxc/info.go:644 lxc/storage_volume.go:1291
 msgid "Backups:"
 msgstr ""
 
@@ -743,118 +738,118 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:330 lxc/network_acl.go:369 lxc/network_forward.go:285
-#: lxc/network_load_balancer.go:287 lxc/network_peer.go:281
-#: lxc/network_zone.go:312 lxc/network_zone.go:871 lxc/storage_bucket.go:137
+#: lxc/network.go:329 lxc/network_acl.go:368 lxc/network_forward.go:284
+#: lxc/network_load_balancer.go:286 lxc/network_peer.go:280
+#: lxc/network_zone.go:311 lxc/network_zone.go:870 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
-#: lxc/storage.go:131 lxc/storage_volume.go:573
+#: lxc/copy.go:135 lxc/init.go:214 lxc/project.go:128 lxc/publish.go:179
+#: lxc/storage.go:130 lxc/storage_volume.go:572
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:757
+#: lxc/image.go:756
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/network.go:843
+#: lxc/network.go:842
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:137 lxc/action.go:310
+#: lxc/action.go:136 lxc/action.go:309
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/network.go:856
+#: lxc/network.go:855
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:835
+#: lxc/info.go:567 lxc/network.go:834
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:836
+#: lxc/info.go:568 lxc/network.go:835
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:166
+#: lxc/operation.go:165
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:411
+#: lxc/config_trust.go:410
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1467
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:209
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:355
+#: lxc/info.go:354
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:572
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:518
+#: lxc/info.go:517
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:522
+#: lxc/info.go:521
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:358
+#: lxc/info.go:357
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:167
+#: lxc/operation.go:166
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:557
+#: lxc/list.go:556
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:983
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:308
+#: lxc/info.go:307
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:117
+#: lxc/move.go:116
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:208
+#: lxc/image.go:207
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:333
+#: lxc/file.go:332
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -863,15 +858,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:856
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:587
+#: lxc/list.go:586
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:459
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -879,11 +874,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1478 lxc/warning.go:225
+#: lxc/list.go:602 lxc/storage_volume.go:1477 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:539
+#: lxc/file.go:538
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -892,70 +887,70 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:103
 msgid "Candid domain to use"
 msgstr ""
 
-#: lxc/init.go:315
+#: lxc/init.go:314
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: lxc/storage_volume.go:410
+#: lxc/storage_volume.go:409
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:368
+#: lxc/storage_volume.go:367
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: lxc/network_acl.go:781
+#: lxc/network_acl.go:780
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: lxc/config_trust.go:191
+#: lxc/config_trust.go:190
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:402 lxc/info.go:414
+#: lxc/info.go:401 lxc/info.go:413
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:114
+#: lxc/info.go:113
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/config_trust.go:631
+#: lxc/config_trust.go:630
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:217
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/network.go:877
+#: lxc/network.go:876
 msgid "Chassis"
 msgstr ""
 
-#: lxc/config_trust.go:215
+#: lxc/config_trust.go:214
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -964,85 +959,85 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:188
+#: lxc/cluster_group.go:187
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:239
+#: lxc/cluster_group.go:238
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:474
+#: lxc/cluster_group.go:473
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:541
+#: lxc/cluster_group.go:540
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1002
+#: lxc/cluster.go:1001
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:134
+#: lxc/cluster_group.go:133
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:494
+#: lxc/cluster_group.go:493
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:630
-#: lxc/config.go:749 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56
-#: lxc/move.go:66 lxc/network.go:297 lxc/network.go:718 lxc/network.go:776
-#: lxc/network.go:1116 lxc/network.go:1183 lxc/network.go:1245
-#: lxc/network_forward.go:171 lxc/network_forward.go:235
-#: lxc/network_forward.go:390 lxc/network_forward.go:491
-#: lxc/network_forward.go:633 lxc/network_forward.go:710
-#: lxc/network_forward.go:776 lxc/network_load_balancer.go:173
-#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392
-#: lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636
-#: lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776
-#: lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939
-#: lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:658
-#: lxc/storage.go:730 lxc/storage.go:813 lxc/storage_bucket.go:86
-#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:249
-#: lxc/storage_bucket.go:378 lxc/storage_bucket.go:523
-#: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
-#: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:532
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:1053 lxc/storage_volume.go:1141
-#: lxc/storage_volume.go:1572 lxc/storage_volume.go:1604
-#: lxc/storage_volume.go:1720 lxc/storage_volume.go:1811
-#: lxc/storage_volume.go:1904 lxc/storage_volume.go:1941
-#: lxc/storage_volume.go:2034 lxc/storage_volume.go:2106
-#: lxc/storage_volume.go:2248
+#: lxc/config.go:749 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:55
+#: lxc/move.go:65 lxc/network.go:296 lxc/network.go:717 lxc/network.go:775
+#: lxc/network.go:1115 lxc/network.go:1182 lxc/network.go:1244
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:632 lxc/network_forward.go:709
+#: lxc/network_forward.go:775 lxc/network_load_balancer.go:172
+#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:391
+#: lxc/network_load_balancer.go:492 lxc/network_load_balancer.go:635
+#: lxc/network_load_balancer.go:711 lxc/network_load_balancer.go:775
+#: lxc/network_load_balancer.go:876 lxc/network_load_balancer.go:938
+#: lxc/storage.go:99 lxc/storage.go:345 lxc/storage.go:406 lxc/storage.go:657
+#: lxc/storage.go:729 lxc/storage.go:812 lxc/storage_bucket.go:85
+#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:522
+#: lxc/storage_bucket.go:598 lxc/storage_bucket.go:662
+#: lxc/storage_bucket.go:813 lxc/storage_bucket.go:891
+#: lxc/storage_bucket.go:956 lxc/storage_bucket.go:1092
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:531
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:851
+#: lxc/storage_volume.go:1052 lxc/storage_volume.go:1140
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1810
+#: lxc/storage_volume.go:1903 lxc/storage_volume.go:1940
+#: lxc/storage_volume.go:2033 lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2247
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:767
+#: lxc/cluster.go:766
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:790
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:637
+#: lxc/cluster.go:636
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1360
-#: lxc/warning.go:93
+#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1359
+#: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
 
@@ -1058,34 +1053,34 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:39
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:42
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:49
+#: lxc/copy.go:52 lxc/init.go:48
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:96
+#: lxc/project.go:95
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:58
+#: lxc/move.go:57
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
-#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:315
-#: lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582
-#: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
-#: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
-#: lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311
-#: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:985 lxc/storage_volume.go:1017
+#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
+#: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
+#: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
+#: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
+#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1055
+#: lxc/storage_volume.go:984 lxc/storage_volume.go:1016
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1094,33 +1089,33 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:532
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1231
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:118
+#: lxc/info.go:117
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/move.go:64
+#: lxc/copy.go:58 lxc/move.go:63
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:152
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:144
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:146
+#: lxc/image.go:145
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1128,11 +1123,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: lxc/copy.go:40
+#: lxc/copy.go:39
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/copy.go:41
+#: lxc/copy.go:40
 msgid ""
 "Copy instances within or in between LXD servers\n"
 "\n"
@@ -1152,114 +1147,114 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:248 lxc/profile.go:249
+#: lxc/profile.go:247 lxc/profile.go:248
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:329 lxc/storage_volume.go:330
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:329
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:58
+#: lxc/copy.go:57
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:335
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:158 lxc/move.go:67 lxc/profile.go:251
-#: lxc/storage_volume.go:337
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/storage_volume.go:336
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:155
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:264
+#: lxc/image.go:263
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:432
+#: lxc/storage_volume.go:431
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:316
+#: lxc/info.go:315
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:314
+#: lxc/info.go:313
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:223 lxc/remote.go:464
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1066
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1070
+#: lxc/cluster.go:1069
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1075
+#: lxc/cluster.go:1074
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1080
+#: lxc/cluster.go:1079
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1097
+#: lxc/cluster.go:1096
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: lxc/network_zone.go:1251
+#: lxc/network_zone.go:1250
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:149 lxc/cluster_group.go:150
+#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:58
 msgid "Create a virtual machine"
 msgstr ""
 
-#: lxc/image_alias.go:60 lxc/image_alias.go:61
+#: lxc/image_alias.go:59 lxc/image_alias.go:60
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:58
+#: lxc/init.go:57
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/launch.go:24 lxc/launch.go:25
+#: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:467
+#: lxc/file.go:243 lxc/file.go:466
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1275,149 +1270,149 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:40 lxc/init.go:41
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:810 lxc/storage_bucket.go:811
+#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:810
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:528 lxc/storage_volume.go:529
+#: lxc/storage_volume.go:527 lxc/storage_volume.go:528
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/config_template.go:67 lxc/config_template.go:68
+#: lxc/config_template.go:66 lxc/config_template.go:67
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network_acl.go:313 lxc/network_acl.go:314
+#: lxc/network_acl.go:312 lxc/network_acl.go:313
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:231 lxc/network_forward.go:232
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:232 lxc/network_load_balancer.go:233
 msgid "Create new network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:215 lxc/network_peer.go:216
+#: lxc/network_peer.go:214 lxc/network_peer.go:215
 msgid "Create new network peering"
 msgstr ""
 
-#: lxc/network_zone.go:818 lxc/network_zone.go:819
+#: lxc/network_zone.go:817 lxc/network_zone.go:818
 msgid "Create new network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:258 lxc/network_zone.go:259
+#: lxc/network_zone.go:257 lxc/network_zone.go:258
 msgid "Create new network zones"
 msgstr ""
 
-#: lxc/network.go:289 lxc/network.go:290
+#: lxc/network.go:288 lxc/network.go:289
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:309 lxc/profile.go:310
+#: lxc/profile.go:308 lxc/profile.go:309
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:94
+#: lxc/project.go:92 lxc/project.go:93
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:96 lxc/storage.go:97
+#: lxc/storage.go:95 lxc/storage.go:96
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:57
+#: lxc/copy.go:62 lxc/init.go:56
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1246
+#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1245
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:162
+#: lxc/init.go:161
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:160
+#: lxc/init.go:159
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:147
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
-#: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:969
-#: lxc/network_acl.go:149 lxc/network_forward.go:146
-#: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
-#: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
-#: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1467
+#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
+#: lxc/network_acl.go:148 lxc/network_forward.go:145
+#: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
+#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
+#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
+#: lxc/storage_volume.go:1466
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:559
+#: lxc/list.go:558
 msgid "DISK USAGE"
 msgstr ""
 
-#: lxc/storage.go:628
+#: lxc/storage.go:627
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 msgid "DRM:"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:859
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2104
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:54 lxc/operation.go:55
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:204 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:361
+#: lxc/warning.go:360
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:118 lxc/file.go:119
+#: lxc/file.go:117 lxc/file.go:118
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:107 lxc/image_alias.go:108
+#: lxc/image_alias.go:106 lxc/image_alias.go:107
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:312 lxc/image.go:313
+#: lxc/image.go:311 lxc/image.go:312
 msgid "Delete images"
 msgstr ""
 
-#: lxc/config_template.go:110 lxc/config_template.go:111
+#: lxc/config_template.go:109 lxc/config_template.go:110
 msgid "Delete instance file templates"
 msgstr ""
 
@@ -1425,72 +1420,72 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:889
+#: lxc/storage_bucket.go:887 lxc/storage_bucket.go:888
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: lxc/network_acl.go:663 lxc/network_acl.go:664
+#: lxc/network_acl.go:662 lxc/network_acl.go:663
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:629 lxc/network_forward.go:630
+#: lxc/network_forward.go:628 lxc/network_forward.go:629
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:633
+#: lxc/network_load_balancer.go:631 lxc/network_load_balancer.go:632
 msgid "Delete network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:605 lxc/network_peer.go:606
+#: lxc/network_peer.go:604 lxc/network_peer.go:605
 msgid "Delete network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1099 lxc/network_zone.go:1100
+#: lxc/network_zone.go:1098 lxc/network_zone.go:1099
 msgid "Delete network zone record"
 msgstr ""
 
-#: lxc/network_zone.go:545 lxc/network_zone.go:546
+#: lxc/network_zone.go:544 lxc/network_zone.go:545
 msgid "Delete network zones"
 msgstr ""
 
-#: lxc/network.go:368 lxc/network.go:369
+#: lxc/network.go:367 lxc/network.go:368
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:363 lxc/profile.go:364
+#: lxc/profile.go:362 lxc/profile.go:363
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:158 lxc/project.go:159
+#: lxc/project.go:157 lxc/project.go:158
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:184
+#: lxc/storage_bucket.go:182 lxc/storage_bucket.go:183
 msgid "Delete storage buckets"
 msgstr ""
 
-#: lxc/storage.go:170 lxc/storage.go:171
+#: lxc/storage.go:169 lxc/storage.go:170
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:607 lxc/storage_volume.go:608
+#: lxc/storage_volume.go:606 lxc/storage_volume.go:607
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:357 lxc/warning.go:358
+#: lxc/warning.go:356 lxc/warning.go:357
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:71 lxc/action.go:92
-#: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
-#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
-#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
-#: lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023
-#: lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
-#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
-#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
+#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
+#: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
+#: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
+#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
 #: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
@@ -1498,112 +1493,112 @@ msgstr ""
 #: lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555
 #: lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27
 #: lxc/config_metadata.go:55 lxc/config_metadata.go:180
-#: lxc/config_template.go:28 lxc/config_template.go:68
-#: lxc/config_template.go:111 lxc/config_template.go:153
-#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
-#: lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351
-#: lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581
-#: lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
-#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
-#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
-#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
-#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
-#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
-#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
-#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
-#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
-#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
-#: lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504
-#: lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896
-#: lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110
-#: lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30
-#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
-#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
-#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
-#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
-#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
-#: lxc/network_forward.go:168 lxc/network_forward.go:232
-#: lxc/network_forward.go:328 lxc/network_forward.go:383
-#: lxc/network_forward.go:461 lxc/network_forward.go:488
-#: lxc/network_forward.go:630 lxc/network_forward.go:692
-#: lxc/network_forward.go:707 lxc/network_forward.go:772
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
-#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
-#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
-#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
-#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
-#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
-#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
-#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
-#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
-#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
-#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
-#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
-#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
-#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
-#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
-#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
-#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
-#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
-#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
-#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
-#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
-#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
-#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:348 lxc/project.go:398
-#: lxc/project.go:511 lxc/project.go:566 lxc/project.go:626 lxc/project.go:655
-#: lxc/project.go:708 lxc/project.go:767 lxc/publish.go:33 lxc/query.go:34
-#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
-#: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
-#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
-#: lxc/storage.go:403 lxc/storage.go:575 lxc/storage.go:652 lxc/storage.go:726
-#: lxc/storage.go:810 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
-#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
-#: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
-#: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
-#: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:811
-#: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
-#: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:529
-#: lxc/storage_volume.go:608 lxc/storage_volume.go:683
-#: lxc/storage_volume.go:765 lxc/storage_volume.go:846
-#: lxc/storage_volume.go:1050 lxc/storage_volume.go:1138
-#: lxc/storage_volume.go:1278 lxc/storage_volume.go:1362
-#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1601
-#: lxc/storage_volume.go:1714 lxc/storage_volume.go:1802
-#: lxc/storage_volume.go:1901 lxc/storage_volume.go:1935
-#: lxc/storage_volume.go:2032 lxc/storage_volume.go:2099
-#: lxc/storage_volume.go:2243 lxc/version.go:22 lxc/warning.go:30
-#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/config_template.go:27 lxc/config_template.go:67
+#: lxc/config_template.go:110 lxc/config_template.go:152
+#: lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34
+#: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
+#: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
+#: lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:31 lxc/file.go:78 lxc/file.go:118
+#: lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216
+#: lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503
+#: lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895
+#: lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109
+#: lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396
+#: lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614
+#: lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727
+#: lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:629 lxc/network_forward.go:691
+#: lxc/network_forward.go:706 lxc/network_forward.go:771
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489
+#: lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693
+#: lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873
+#: lxc/network_load_balancer.go:934 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453
+#: lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209
+#: lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399
+#: lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593
+#: lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770
+#: lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954
+#: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
+#: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
+#: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
+#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
+#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
+#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
+#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
+#: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
+#: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664
+#: lxc/remote.go:752 lxc/remote.go:824 lxc/remote.go:879 lxc/remote.go:917
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342
+#: lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725
+#: lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:441
+#: lxc/storage_bucket.go:516 lxc/storage_bucket.go:593
+#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:810
+#: lxc/storage_bucket.go:888 lxc/storage_bucket.go:952
+#: lxc/storage_bucket.go:1087 lxc/storage_volume.go:41
+#: lxc/storage_volume.go:163 lxc/storage_volume.go:238
+#: lxc/storage_volume.go:329 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:682
+#: lxc/storage_volume.go:764 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1277 lxc/storage_volume.go:1361
+#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1713 lxc/storage_volume.go:1801
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1934
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2098
+#: lxc/storage_volume.go:2242 lxc/version.go:22 lxc/warning.go:29
+#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1218
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1573
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:1572
 msgid "Destination cluster member name"
 msgstr ""
 
-#: lxc/network.go:418 lxc/network.go:419
+#: lxc/network.go:417 lxc/network.go:418
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:503 lxc/network.go:504
+#: lxc/network.go:502 lxc/network.go:503
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:682 lxc/storage_volume.go:683
+#: lxc/storage_volume.go:681 lxc/storage_volume.go:682
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:764 lxc/storage_volume.go:765
+#: lxc/storage_volume.go:763 lxc/storage_volume.go:764
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1648,16 +1643,16 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:267 lxc/info.go:291
+#: lxc/info.go:266 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:405
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:667
+#: lxc/image.go:666
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1665,7 +1660,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:975
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1677,28 +1672,28 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:426
+#: lxc/info.go:425
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:511
+#: lxc/info.go:510
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:421
+#: lxc/info.go:420
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:424
+#: lxc/info.go:423
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:136
+#: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:488
+#: lxc/cluster.go:487
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1706,54 +1701,54 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/network.go:847
+#: lxc/network.go:846
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:106 lxc/info.go:192
+#: lxc/info.go:105 lxc/info.go:191
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/network_zone.go:705
+#: lxc/network_zone.go:704
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:867
+#: lxc/list.go:866
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:928 lxc/config_trust.go:517
+#: lxc/cluster.go:927 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
-#: lxc/config_trust.go:414
+#: lxc/config_trust.go:413
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:70
+#: lxc/file.go:69
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:255
+#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:650 lxc/cluster.go:651
+#: lxc/cluster.go:649 lxc/cluster.go:650
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:167 lxc/file.go:168
+#: lxc/file.go:166 lxc/file.go:167
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/image.go:363 lxc/image.go:364
+#: lxc/image.go:362 lxc/image.go:363
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config_template.go:152 lxc/config_template.go:153
+#: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
 
@@ -1765,73 +1760,73 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network_acl.go:483 lxc/network_acl.go:484
+#: lxc/network_acl.go:482 lxc/network_acl.go:483
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:588 lxc/network.go:589
+#: lxc/network.go:587 lxc/network.go:588
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_forward.go:488
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:489
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: lxc/network_peer.go:480 lxc/network_peer.go:481
+#: lxc/network_peer.go:479 lxc/network_peer.go:480
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:426 lxc/network_zone.go:427
+#: lxc/network_zone.go:425 lxc/network_zone.go:426
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: lxc/network_zone.go:981 lxc/network_zone.go:982
+#: lxc/network_zone.go:980 lxc/network_zone.go:981
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:413 lxc/profile.go:414
+#: lxc/profile.go:412 lxc/profile.go:413
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:221 lxc/project.go:222
+#: lxc/project.go:220 lxc/project.go:221
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:245
+#: lxc/storage_bucket.go:243 lxc/storage_bucket.go:244
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:952 lxc/storage_bucket.go:953
+#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:952
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: lxc/storage.go:220 lxc/storage.go:221
+#: lxc/storage.go:219 lxc/storage.go:220
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:845 lxc/storage_volume.go:846
+#: lxc/storage_volume.go:844 lxc/storage_volume.go:845
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/config_trust.go:236 lxc/config_trust.go:237
+#: lxc/config_trust.go:235 lxc/config_trust.go:236
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1495
-#: lxc/warning.go:236
+#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1494
+#: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:565
+#: lxc/cluster.go:564
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:565
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1846,7 +1841,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: lxc/network_zone.go:1166
+#: lxc/network_zone.go:1165
 msgid "Entry TTL"
 msgstr ""
 
@@ -1854,25 +1849,25 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:52
+#: lxc/copy.go:55 lxc/init.go:51
 msgid "Ephemeral instance"
 msgstr ""
 
-#: lxc/publish.go:234
+#: lxc/publish.go:233
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/config_template.go:206
+#: lxc/config_template.go:205
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1129 lxc/cluster.go:1130
+#: lxc/cluster.go:1128 lxc/cluster.go:1129
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1209
+#: lxc/cluster.go:1208
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1900,80 +1895,80 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1279
-#: lxc/storage_volume.go:1329
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1278
+#: lxc/storage_volume.go:1328
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:958
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:961
+#: lxc/image.go:960
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:489
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:491
+#: lxc/image.go:490
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2098 lxc/storage_volume.go:2099
+#: lxc/storage_volume.go:2097 lxc/storage_volume.go:2098
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:30
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:31
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2101
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2211
+#: lxc/export.go:143 lxc/storage_volume.go:2210
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:558
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:188
+#: lxc/cluster.go:187
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: lxc/config_template.go:284
+#: lxc/config_template.go:283
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:412 lxc/image.go:1056 lxc/image.go:1057
-#: lxc/image_alias.go:236
+#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:210
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1218
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1241
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -1988,37 +1983,37 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1268
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1053
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: lxc/config_trust.go:211
+#: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1174
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: lxc/network_peer.go:305
+#: lxc/network_peer.go:304
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: lxc/init.go:294
+#: lxc/init.go:293
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1179
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2028,31 +2023,31 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1079
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1206
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:189
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:240
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:285 lxc/move.go:361 lxc/move.go:413
+#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:230
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2062,26 +2057,26 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:255
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:262
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:413
+#: lxc/copy.go:412
 msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:359
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2091,35 +2086,35 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:801
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:235
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:927 lxc/network_acl.go:125 lxc/network_zone.go:116
-#: lxc/operation.go:134
+#: lxc/network.go:926 lxc/network_acl.go:124 lxc/network_zone.go:115
+#: lxc/operation.go:133
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:943
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1132
+#: lxc/cluster.go:1131
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1159
+#: lxc/cluster.go:1158
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2127,11 +2122,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:487
+#: lxc/cluster.go:486
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:126
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2143,7 +2138,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:495
+#: lxc/cluster.go:494
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2167,16 +2162,16 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:843
-#: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:353
-#: lxc/config_trust.go:435 lxc/image.go:1046 lxc/image_alias.go:158
-#: lxc/list.go:134 lxc/network.go:900 lxc/network.go:991 lxc/network_acl.go:98
-#: lxc/network_forward.go:90 lxc/network_load_balancer.go:94
-#: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654
-#: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:400
-#: lxc/project.go:769 lxc/remote.go:669 lxc/storage.go:577
-#: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1378 lxc/warning.go:94
+#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
+#: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
+#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
+#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
+#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
+#: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
+#: lxc/storage_volume.go:1377 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2188,7 +2183,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: lxc/network.go:859
+#: lxc/network.go:858
 msgid "Forward delay"
 msgstr ""
 
@@ -2197,30 +2192,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:317 lxc/info.go:328
+#: lxc/info.go:316 lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:326
+#: lxc/info.go:325
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:736
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:397
+#: lxc/info.go:396
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:400
+#: lxc/info.go:399
 msgid "GPUs:"
 msgstr ""
 
@@ -2228,23 +2223,23 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:158 lxc/remote.go:391
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/project.go:766 lxc/project.go:767
+#: lxc/project.go:765 lxc/project.go:766
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1477 lxc/image.go:1478
+#: lxc/image.go:1476 lxc/image.go:1477
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:772 lxc/network.go:773
+#: lxc/network.go:771 lxc/network.go:772
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:304
+#: lxc/cluster.go:303
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2256,55 +2251,55 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:264 lxc/network_acl.go:265
+#: lxc/network_acl.go:263 lxc/network_acl.go:264
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:714 lxc/network.go:715
+#: lxc/network.go:713 lxc/network.go:714
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:327 lxc/network_forward.go:328
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:330
+#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:329
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:329 lxc/network_peer.go:330
+#: lxc/network_peer.go:328 lxc/network_peer.go:329
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:209 lxc/network_zone.go:210
+#: lxc/network_zone.go:208 lxc/network_zone.go:209
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:770 lxc/network_zone.go:771
+#: lxc/network_zone.go:769 lxc/network_zone.go:770
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:539 lxc/profile.go:540
+#: lxc/profile.go:538 lxc/profile.go:539
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:347 lxc/project.go:348
+#: lxc/project.go:346 lxc/project.go:347
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:375 lxc/storage_bucket.go:376
+#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:375
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:342 lxc/storage.go:343
+#: lxc/storage.go:341 lxc/storage.go:342
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1050
+#: lxc/storage_volume.go:1048 lxc/storage_volume.go:1049
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:392
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2313,85 +2308,85 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:1036
+#: lxc/network.go:1035
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:557
+#: lxc/info.go:556
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379
+#: lxc/info.go:367 lxc/info.go:378
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1291
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1280
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1103
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1113
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:162
+#: lxc/network.go:856 lxc/operation.go:161
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:110
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:199 lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:487
+#: lxc/project.go:486
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1038
+#: lxc/network.go:1037
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:573
+#: lxc/info.go:572
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/network.go:826
+#: lxc/network.go:825
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:967
+#: lxc/list.go:552 lxc/network.go:966
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:554 lxc/network.go:968
+#: lxc/list.go:553 lxc/network.go:967
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:413
+#: lxc/config_trust.go:412
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/publish.go:42
+#: lxc/publish.go:41
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1940
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1939
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2405,94 +2400,94 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1938
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:65 lxc/move.go:68
+#: lxc/copy.go:64 lxc/move.go:67
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:118
+#: lxc/action.go:117
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1400
+#: lxc/image.go:1399
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:281
+#: lxc/image.go:280
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:41
+#: lxc/publish.go:40
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:635
+#: lxc/image.go:634
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:1362
+#: lxc/image.go:335 lxc/image.go:1361
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:404 lxc/image.go:1554
+#: lxc/image.go:403 lxc/image.go:1553
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:855
+#: lxc/image.go:854
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1398
+#: lxc/image.go:1397
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:122 lxc/launch.go:42
+#: lxc/action.go:121 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2242
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:29
+#: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2242
+#: lxc/storage_volume.go:2241
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:652
+#: lxc/image.go:651
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:650
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2296
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:95
+#: lxc/import.go:94
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:228
+#: lxc/info.go:227
 msgid "Infiniband:"
 msgstr ""
 
@@ -2500,42 +2495,42 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:683
+#: lxc/info.go:682
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1105
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1282
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:80
+#: lxc/publish.go:79
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:419 lxc/init.go:413
+#: lxc/copy.go:418 lxc/init.go:412
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:346
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:54
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2545,23 +2540,18 @@ msgstr ""
 msgid "Invalid argument %q"
 msgstr ""
 
-#: lxc/config_trust.go:392
+#: lxc/config_trust.go:391
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:649
+#: lxc/list.go:648
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:642
+#: lxc/list.go:641
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
-msgstr ""
-
-#: lxc/utils/table.go:65
-#, c-format
-msgid "Invalid format %q"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -2574,7 +2564,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1020
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2584,31 +2574,31 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:670
+#: lxc/list.go:669
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:666
+#: lxc/list.go:665
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:656
+#: lxc/list.go:655
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1652
+#: lxc/move.go:134 lxc/storage_volume.go:1651
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:131
+#: lxc/move.go:130
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1648
+#: lxc/storage_volume.go:1647
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2616,60 +2606,60 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:143
+#: lxc/file.go:142
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:1086
-#: lxc/storage_volume.go:1174 lxc/storage_volume.go:1637
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1085
+#: lxc/storage_volume.go:1173 lxc/storage_volume.go:1636
+#: lxc/storage_volume.go:1757 lxc/storage_volume.go:1843
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:306
+#: lxc/file.go:305
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:488
+#: lxc/file.go:487
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:231
+#: lxc/info.go:230
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:154
+#: lxc/image.go:153
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:212
+#: lxc/warning.go:211
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:828
+#: lxc/project.go:827
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:145 lxc/network_load_balancer.go:148
+#: lxc/network_forward.go:144 lxc/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:599 lxc/network.go:1043 lxc/network_forward.go:152
-#: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1474 lxc/warning.go:221
+#: lxc/list.go:598 lxc/network.go:1042 lxc/network_forward.go:151
+#: lxc/network_load_balancer.go:153 lxc/operation.go:168
+#: lxc/storage_bucket.go:499 lxc/storage_volume.go:1473 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
 
@@ -2681,123 +2671,123 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:159 lxc/cluster.go:877 lxc/cluster.go:971 lxc/cluster.go:1062
-#: lxc/cluster_group.go:404
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
+#: lxc/cluster_group.go:403
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:492
+#: lxc/info.go:491
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:965
+#: lxc/image.go:964
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:966
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:222
+#: lxc/info.go:221
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:224
+#: lxc/info.go:223
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:988 lxc/network.go:989
+#: lxc/network.go:987 lxc/network.go:988
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:102 lxc/alias.go:103
+#: lxc/alias.go:101 lxc/alias.go:102
 msgid "List aliases"
 msgstr ""
 
-#: lxc/config_trust.go:432 lxc/config_trust.go:433
+#: lxc/config_trust.go:431 lxc/config_trust.go:432
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:841 lxc/cluster.go:842
+#: lxc/cluster.go:840 lxc/cluster.go:841
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:367 lxc/cluster_group.go:368
+#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:122 lxc/cluster.go:123
+#: lxc/cluster.go:121 lxc/cluster.go:122
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:95
+#: lxc/warning.go:94
 msgid "List all warnings"
 msgstr ""
 
-#: lxc/network_acl.go:95
+#: lxc/network_acl.go:94
 msgid "List available network ACL"
 msgstr ""
 
-#: lxc/network_acl.go:94
+#: lxc/network_acl.go:93
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:86 lxc/network_forward.go:87
+#: lxc/network_forward.go:85 lxc/network_forward.go:86
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:89 lxc/network_load_balancer.go:90
 msgid "List available network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:81 lxc/network_peer.go:82
+#: lxc/network_peer.go:80 lxc/network_peer.go:81
 msgid "List available network peers"
 msgstr ""
 
-#: lxc/network_zone.go:86
+#: lxc/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: lxc/network_zone.go:650 lxc/network_zone.go:651
+#: lxc/network_zone.go:649 lxc/network_zone.go:650
 msgid "List available network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:85
+#: lxc/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:895 lxc/network.go:896
+#: lxc/network.go:894 lxc/network.go:895
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:574 lxc/storage.go:575
+#: lxc/storage.go:573 lxc/storage.go:574
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:104 lxc/operation.go:105
+#: lxc/operation.go:103 lxc/operation.go:104
 msgid "List background operations"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:151
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:153
+#: lxc/image_alias.go:152
 msgid ""
 "List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1018
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1020
+#: lxc/image.go:1019
 msgid ""
 "List images\n"
 "\n"
@@ -2828,15 +2818,15 @@ msgstr ""
 msgid "List instance devices"
 msgstr ""
 
-#: lxc/config_template.go:240 lxc/config_template.go:241
+#: lxc/config_template.go:239 lxc/config_template.go:240
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:50
+#: lxc/list.go:49
 #, c-format
 msgid ""
 "List instances\n"
@@ -2919,31 +2909,31 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/config_trust.go:102
+#: lxc/config_trust.go:101
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:588 lxc/profile.go:589
+#: lxc/profile.go:587 lxc/profile.go:588
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:396 lxc/project.go:397
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:730 lxc/storage_bucket.go:732
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:440 lxc/storage_bucket.go:442
+#: lxc/storage_bucket.go:439 lxc/storage_bucket.go:441
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1357
+#: lxc/storage_volume.go:1356
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1362
+#: lxc/storage_volume.go:1361
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,19 +2952,19 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:350 lxc/config_trust.go:351
+#: lxc/config_trust.go:349 lxc/config_trust.go:350
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:70
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:72
+#: lxc/warning.go:71
 msgid ""
 "List warnings\n"
 "\n"
@@ -2997,11 +2987,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:22 lxc/operation.go:23
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1235
+#: lxc/info.go:479 lxc/storage_volume.go:1234
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3010,91 +3000,91 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:711
+#: lxc/info.go:710
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:869
+#: lxc/network.go:868
 msgid "Lower device"
 msgstr ""
 
-#: lxc/network.go:850
+#: lxc/network.go:849
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1037
+#: lxc/network.go:1036
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:561
+#: lxc/info.go:560
 msgid "MAC address"
 msgstr ""
 
-#: lxc/network.go:818
+#: lxc/network.go:817
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:235
+#: lxc/info.go:234
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:966
+#: lxc/network.go:965
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:424
+#: lxc/cluster_group.go:423
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:564
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:191
+#: lxc/cluster.go:190
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:848
+#: lxc/network.go:847
 msgid "MII Frequency"
 msgstr ""
 
-#: lxc/network.go:849
+#: lxc/network.go:848
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:565
+#: lxc/info.go:564
 msgid "MTU"
 msgstr ""
 
-#: lxc/network.go:819
+#: lxc/network.go:818
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:152 lxc/image.go:657
+#: lxc/image.go:151 lxc/image.go:656
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:36
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:32 lxc/network.go:33
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
 msgid "Manage cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:29 lxc/cluster.go:30
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -3102,7 +3092,7 @@ msgstr ""
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:21 lxc/alias.go:22
+#: lxc/alias.go:20 lxc/alias.go:21
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3110,19 +3100,19 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:78 lxc/file.go:79
+#: lxc/file.go:77 lxc/file.go:78
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/image_alias.go:24 lxc/image_alias.go:25
+#: lxc/image_alias.go:23 lxc/image_alias.go:24
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:36
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:37
 msgid ""
 "Manage images\n"
 "\n"
@@ -3145,7 +3135,7 @@ msgstr ""
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:26 lxc/config_template.go:27
 msgid "Manage instance file templates"
 msgstr ""
 
@@ -3153,108 +3143,108 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:712 lxc/network_acl.go:713
+#: lxc/network_acl.go:711 lxc/network_acl.go:712
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: lxc/network_acl.go:29 lxc/network_acl.go:30
+#: lxc/network_acl.go:28 lxc/network_acl.go:29
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:691 lxc/network_forward.go:692
+#: lxc/network_forward.go:690 lxc/network_forward.go:691
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:29 lxc/network_forward.go:30
+#: lxc/network_forward.go:28 lxc/network_forward.go:29
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:692 lxc/network_load_balancer.go:693
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:859
+#: lxc/network_load_balancer.go:857 lxc/network_load_balancer.go:858
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:30
+#: lxc/network_load_balancer.go:28 lxc/network_load_balancer.go:29
 msgid "Manage network load balancers"
 msgstr ""
 
-#: lxc/network_peer.go:28 lxc/network_peer.go:29
+#: lxc/network_peer.go:27 lxc/network_peer.go:28
 msgid "Manage network peerings"
 msgstr ""
 
-#: lxc/network_zone.go:1148 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1147 lxc/network_zone.go:1148
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: lxc/network_zone.go:593 lxc/network_zone.go:594
+#: lxc/network_zone.go:592 lxc/network_zone.go:593
 msgid "Manage network zone records"
 msgstr ""
 
-#: lxc/network_zone.go:28 lxc/network_zone.go:29
+#: lxc/network_zone.go:27 lxc/network_zone.go:28
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:28 lxc/profile.go:29
+#: lxc/profile.go:27 lxc/profile.go:28
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:29 lxc/project.go:30
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:691
+#: lxc/storage_bucket.go:690
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:692
+#: lxc/storage_bucket.go:691
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:28
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets."
 msgstr ""
 
-#: lxc/storage.go:33 lxc/storage.go:34
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:41
+#: lxc/storage_volume.go:40
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:41
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:32 lxc/remote.go:33
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:34 lxc/config_trust.go:35
+#: lxc/config_trust.go:33 lxc/config_trust.go:34
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/warning.go:29 lxc/warning.go:30
+#: lxc/warning.go:28 lxc/warning.go:29
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:139 lxc/info.go:248
+#: lxc/info.go:138 lxc/info.go:247
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:150
+#: lxc/info.go:149
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3268,43 +3258,43 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:822
+#: lxc/cluster.go:821
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:550
+#: lxc/cluster.go:549
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:463
+#: lxc/cluster.go:462
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:529
+#: lxc/info.go:528
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:533
+#: lxc/info.go:532
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:545
+#: lxc/info.go:544
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:366
+#: lxc/info.go:365
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:303 lxc/move.go:375 lxc/move.go:427
+#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:328 lxc/move.go:380 lxc/move.go:432
+#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3314,51 +3304,51 @@ msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:112 lxc/storage_bucket.go:212
-#: lxc/storage_bucket.go:288 lxc/storage_bucket.go:404
-#: lxc/storage_bucket.go:549 lxc/storage_bucket.go:625
-#: lxc/storage_bucket.go:761 lxc/storage_bucket.go:842
-#: lxc/storage_bucket.go:917 lxc/storage_bucket.go:996
-#: lxc/storage_bucket.go:1119
+#: lxc/storage_bucket.go:111 lxc/storage_bucket.go:211
+#: lxc/storage_bucket.go:287 lxc/storage_bucket.go:403
+#: lxc/storage_bucket.go:548 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:760 lxc/storage_bucket.go:841
+#: lxc/storage_bucket.go:916 lxc/storage_bucket.go:995
+#: lxc/storage_bucket.go:1118
 msgid "Missing bucket name"
 msgstr ""
 
-#: lxc/config_trust.go:269 lxc/config_trust.go:677
+#: lxc/config_trust.go:268 lxc/config_trust.go:676
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:174 lxc/cluster_group.go:229 lxc/cluster_group.go:279
-#: lxc/cluster_group.go:581
+#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
+#: lxc/cluster_group.go:580
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:684 lxc/cluster.go:1180 lxc/cluster_group.go:110
-#: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
+#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
-#: lxc/config_template.go:92 lxc/config_template.go:135
-#: lxc/config_template.go:177 lxc/config_template.go:266
-#: lxc/config_template.go:325 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:674
+#: lxc/config_template.go:91 lxc/config_template.go:134
+#: lxc/config_template.go:176 lxc/config_template.go:265
+#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
+#: lxc/profile.go:673
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:846 lxc/storage_bucket.go:921
-#: lxc/storage_bucket.go:1000 lxc/storage_bucket.go:1123
+#: lxc/storage_bucket.go:845 lxc/storage_bucket.go:920
+#: lxc/storage_bucket.go:999 lxc/storage_bucket.go:1122
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:196 lxc/network_forward.go:260
-#: lxc/network_forward.go:355 lxc/network_forward.go:415
-#: lxc/network_forward.go:539 lxc/network_forward.go:658
-#: lxc/network_forward.go:735 lxc/network_forward.go:801
-#: lxc/network_load_balancer.go:198 lxc/network_load_balancer.go:262
-#: lxc/network_load_balancer.go:357 lxc/network_load_balancer.go:417
-#: lxc/network_load_balancer.go:541 lxc/network_load_balancer.go:661
-#: lxc/network_load_balancer.go:737 lxc/network_load_balancer.go:801
-#: lxc/network_load_balancer.go:902 lxc/network_load_balancer.go:964
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:538 lxc/network_forward.go:657
+#: lxc/network_forward.go:734 lxc/network_forward.go:800
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:356 lxc/network_load_balancer.go:416
+#: lxc/network_load_balancer.go:540 lxc/network_load_balancer.go:660
+#: lxc/network_load_balancer.go:736 lxc/network_load_balancer.go:800
+#: lxc/network_load_balancer.go:901 lxc/network_load_balancer.go:963
 msgid "Missing listen address"
 msgstr ""
 
@@ -3368,107 +3358,107 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network_acl.go:188 lxc/network_acl.go:240 lxc/network_acl.go:287
-#: lxc/network_acl.go:337 lxc/network_acl.go:424 lxc/network_acl.go:534
-#: lxc/network_acl.go:637 lxc/network_acl.go:686 lxc/network_acl.go:806
-#: lxc/network_acl.go:873
+#: lxc/network_acl.go:187 lxc/network_acl.go:239 lxc/network_acl.go:286
+#: lxc/network_acl.go:336 lxc/network_acl.go:423 lxc/network_acl.go:533
+#: lxc/network_acl.go:636 lxc/network_acl.go:685 lxc/network_acl.go:805
+#: lxc/network_acl.go:872
 msgid "Missing network ACL name"
 msgstr ""
 
-#: lxc/network.go:156 lxc/network.go:241 lxc/network.go:393 lxc/network.go:443
-#: lxc/network.go:528 lxc/network.go:633 lxc/network.go:741 lxc/network.go:799
-#: lxc/network.go:1014 lxc/network.go:1084 lxc/network.go:1139
-#: lxc/network.go:1206 lxc/network_forward.go:116 lxc/network_forward.go:192
-#: lxc/network_forward.go:256 lxc/network_forward.go:351
-#: lxc/network_forward.go:411 lxc/network_forward.go:535
-#: lxc/network_forward.go:654 lxc/network_forward.go:731
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:120
-#: lxc/network_load_balancer.go:194 lxc/network_load_balancer.go:258
-#: lxc/network_load_balancer.go:353 lxc/network_load_balancer.go:413
-#: lxc/network_load_balancer.go:537 lxc/network_load_balancer.go:657
-#: lxc/network_load_balancer.go:733 lxc/network_load_balancer.go:797
-#: lxc/network_load_balancer.go:898 lxc/network_load_balancer.go:960
-#: lxc/network_peer.go:111 lxc/network_peer.go:181 lxc/network_peer.go:238
-#: lxc/network_peer.go:353 lxc/network_peer.go:411 lxc/network_peer.go:519
-#: lxc/network_peer.go:628
+#: lxc/network.go:155 lxc/network.go:240 lxc/network.go:392 lxc/network.go:442
+#: lxc/network.go:527 lxc/network.go:632 lxc/network.go:740 lxc/network.go:798
+#: lxc/network.go:1013 lxc/network.go:1083 lxc/network.go:1138
+#: lxc/network.go:1205 lxc/network_forward.go:115 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:534
+#: lxc/network_forward.go:653 lxc/network_forward.go:730
+#: lxc/network_forward.go:796 lxc/network_load_balancer.go:119
+#: lxc/network_load_balancer.go:193 lxc/network_load_balancer.go:257
+#: lxc/network_load_balancer.go:352 lxc/network_load_balancer.go:412
+#: lxc/network_load_balancer.go:536 lxc/network_load_balancer.go:656
+#: lxc/network_load_balancer.go:732 lxc/network_load_balancer.go:796
+#: lxc/network_load_balancer.go:897 lxc/network_load_balancer.go:959
+#: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
+#: lxc/network_peer.go:352 lxc/network_peer.go:410 lxc/network_peer.go:518
+#: lxc/network_peer.go:627
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/network_zone.go:179 lxc/network_zone.go:232 lxc/network_zone.go:282
-#: lxc/network_zone.go:367 lxc/network_zone.go:465 lxc/network_zone.go:568
-#: lxc/network_zone.go:674 lxc/network_zone.go:742 lxc/network_zone.go:841
-#: lxc/network_zone.go:922 lxc/network_zone.go:1121 lxc/network_zone.go:1186
-#: lxc/network_zone.go:1231
+#: lxc/network_zone.go:178 lxc/network_zone.go:231 lxc/network_zone.go:281
+#: lxc/network_zone.go:366 lxc/network_zone.go:464 lxc/network_zone.go:567
+#: lxc/network_zone.go:673 lxc/network_zone.go:741 lxc/network_zone.go:840
+#: lxc/network_zone.go:921 lxc/network_zone.go:1120 lxc/network_zone.go:1185
+#: lxc/network_zone.go:1230
 msgid "Missing network zone name"
 msgstr ""
 
-#: lxc/network_zone.go:792 lxc/network_zone.go:1019
+#: lxc/network_zone.go:791 lxc/network_zone.go:1018
 msgid "Missing network zone record name"
 msgstr ""
 
-#: lxc/network_peer.go:185 lxc/network_peer.go:242 lxc/network_peer.go:357
-#: lxc/network_peer.go:415 lxc/network_peer.go:523 lxc/network_peer.go:632
+#: lxc/network_peer.go:184 lxc/network_peer.go:241 lxc/network_peer.go:356
+#: lxc/network_peer.go:414 lxc/network_peer.go:522 lxc/network_peer.go:631
 msgid "Missing peer name"
 msgstr ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429
-#: lxc/storage.go:681 lxc/storage.go:758 lxc/storage_bucket.go:108
-#: lxc/storage_bucket.go:208 lxc/storage_bucket.go:284
-#: lxc/storage_bucket.go:400 lxc/storage_bucket.go:466
-#: lxc/storage_bucket.go:545 lxc/storage_bucket.go:621
-#: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
-#: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
-#: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:555
-#: lxc/storage_volume.go:632 lxc/storage_volume.go:707
-#: lxc/storage_volume.go:789 lxc/storage_volume.go:888
-#: lxc/storage_volume.go:1075 lxc/storage_volume.go:1401
-#: lxc/storage_volume.go:1626 lxc/storage_volume.go:1741
-#: lxc/storage_volume.go:1833 lxc/storage_volume.go:1961
-#: lxc/storage_volume.go:2056
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:367 lxc/storage.go:428
+#: lxc/storage.go:680 lxc/storage.go:757 lxc/storage_bucket.go:107
+#: lxc/storage_bucket.go:207 lxc/storage_bucket.go:283
+#: lxc/storage_bucket.go:399 lxc/storage_bucket.go:465
+#: lxc/storage_bucket.go:544 lxc/storage_bucket.go:620
+#: lxc/storage_bucket.go:756 lxc/storage_bucket.go:837
+#: lxc/storage_bucket.go:912 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1114 lxc/storage_volume.go:187
+#: lxc/storage_volume.go:262 lxc/storage_volume.go:554
+#: lxc/storage_volume.go:631 lxc/storage_volume.go:706
+#: lxc/storage_volume.go:788 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:1074 lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1625 lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2055
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:334 lxc/profile.go:388 lxc/profile.go:462 lxc/profile.go:564
-#: lxc/profile.go:750 lxc/profile.go:803 lxc/profile.go:859
+#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
+#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:119 lxc/project.go:188 lxc/project.go:270 lxc/project.go:372
-#: lxc/project.go:535 lxc/project.go:593 lxc/project.go:679 lxc/project.go:792
+#: lxc/project.go:118 lxc/project.go:187 lxc/project.go:269 lxc/project.go:371
+#: lxc/project.go:534 lxc/project.go:592 lxc/project.go:678 lxc/project.go:791
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:359
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1163
+#: lxc/storage_volume.go:1162
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:587
+#: lxc/file.go:586
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/network_peer.go:246
+#: lxc/network_peer.go:245
 msgid "Missing target network"
 msgstr ""
 
-#: lxc/network.go:844
+#: lxc/network.go:843
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:270
+#: lxc/info.go:269
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3484,24 +3474,24 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:548 lxc/storage_volume.go:727
-#: lxc/storage_volume.go:808
+#: lxc/network.go:462 lxc/network.go:547 lxc/storage_volume.go:726
+#: lxc/storage_volume.go:807
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:281
+#: lxc/file.go:280
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:966 lxc/file.go:967
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:35
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:37
+#: lxc/move.go:36
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3517,263 +3507,263 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1567 lxc/storage_volume.go:1568
+#: lxc/storage_volume.go:1566 lxc/storage_volume.go:1567
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:61
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1574
+#: lxc/storage_volume.go:1573
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:436
+#: lxc/storage_volume.go:435
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:1008
+#: lxc/network_forward.go:844 lxc/network_load_balancer.go:1007
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/network_acl.go:928
+#: lxc/network_acl.go:927
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:669
+#: lxc/image.go:668
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:221
+#: lxc/action.go:220
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:926 lxc/cluster_group.go:422
-#: lxc/config_trust.go:410 lxc/config_trust.go:515 lxc/list.go:566
-#: lxc/network.go:964 lxc/network_acl.go:148 lxc/network_peer.go:140
-#: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
-#: lxc/project.go:486 lxc/remote.go:730 lxc/storage.go:627
-#: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1466
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
+#: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
+#: lxc/storage_bucket.go:494 lxc/storage_bucket.go:789
+#: lxc/storage_volume.go:1465
 msgid "NAME"
 msgstr ""
 
-#: lxc/project.go:492
+#: lxc/project.go:491
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:491
+#: lxc/project.go:490
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:409
+#: lxc/info.go:408
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:412
+#: lxc/info.go:411
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:941 lxc/operation.go:146 lxc/project.go:444
-#: lxc/project.go:449 lxc/project.go:454 lxc/project.go:459 lxc/project.go:464
-#: lxc/project.go:469 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:940 lxc/operation.go:145 lxc/project.go:443
+#: lxc/project.go:448 lxc/project.go:453 lxc/project.go:458 lxc/project.go:463
+#: lxc/project.go:468 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:91 lxc/info.go:177 lxc/info.go:264
+#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:375
+#: lxc/info.go:374
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1277
-#: lxc/storage_volume.go:1327
+#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1276
+#: lxc/storage_volume.go:1326
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:140
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:817 lxc/storage_volume.go:1217
+#: lxc/info.go:462 lxc/network.go:816 lxc/storage_volume.go:1216
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:304
+#: lxc/info.go:303
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:351
+#: lxc/network.go:350
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:403
+#: lxc/network.go:402
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:349
+#: lxc/network.go:348
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1094
+#: lxc/network.go:1093
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/network_acl.go:381
+#: lxc/network_acl.go:380
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:696
+#: lxc/network_acl.go:695
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:647
+#: lxc/network_acl.go:646
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_zone.go:324
+#: lxc/network_zone.go:323
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: lxc/network_zone.go:578
+#: lxc/network_zone.go:577
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:312
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:675
+#: lxc/network_forward.go:674
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:314
+#: lxc/network_load_balancer.go:313
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:678
+#: lxc/network_load_balancer.go:677
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:53
+#: lxc/init.go:52
 msgid "Network name"
 msgstr ""
 
-#: lxc/network_peer.go:309
+#: lxc/network_peer.go:308
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: lxc/network_peer.go:644
+#: lxc/network_peer.go:643
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: lxc/network_peer.go:313
+#: lxc/network_peer.go:312
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: lxc/network_peer.go:311
+#: lxc/network_peer.go:310
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: lxc/network.go:298
+#: lxc/network.go:297
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:586 lxc/network.go:834
+#: lxc/info.go:585 lxc/network.go:833
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/network_zone.go:883
+#: lxc/network_zone.go:882
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: lxc/network_zone.go:1131
+#: lxc/network_zone.go:1130
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:37
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:155 lxc/image.go:658
+#: lxc/image.go:154 lxc/image.go:657
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/init.go:50 lxc/move.go:58
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/config_trust.go:638
+#: lxc/config_trust.go:637
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1009
+#: lxc/cluster.go:1008
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557
+#: lxc/network.go:471 lxc/network.go:556
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:736 lxc/storage_volume.go:817
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:816
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:832
+#: lxc/network_load_balancer.go:831
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:856 lxc/network_load_balancer.go:1019
+#: lxc/network_forward.go:855 lxc/network_load_balancer.go:1018
 msgid "No matching port(s) found"
 msgstr ""
 
-#: lxc/network_acl.go:939
+#: lxc/network_acl.go:938
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:373
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:420
+#: lxc/storage_volume.go:419
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3782,53 +3772,53 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:377
+#: lxc/info.go:376
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1664
+#: lxc/storage_volume.go:1663
 msgid "Not a snapshot name"
 msgstr ""
 
-#: lxc/network.go:876
+#: lxc/network.go:875
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:208 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:207 lxc/storage_volume.go:282
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2141
+#: lxc/storage_volume.go:2140
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1974
+#: lxc/storage_volume.go:1973
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:325
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:746
+#: lxc/image.go:745
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1181
+#: lxc/storage_volume.go:1180
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:659 lxc/network.go:1154
+#: lxc/network.go:658 lxc/network.go:1153
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:85
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1331
+#: lxc/info.go:683 lxc/storage_volume.go:1330
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3840,57 +3830,57 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:102 lxc/info.go:188
+#: lxc/info.go:101 lxc/info.go:187
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/network_peer.go:142
+#: lxc/network_peer.go:141
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:568
+#: lxc/list.go:567
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:484
+#: lxc/info.go:483
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148 lxc/network_load_balancer.go:150
+#: lxc/network_forward.go:147 lxc/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:569 lxc/project.go:488
+#: lxc/list.go:568 lxc/project.go:487
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1485 lxc/warning.go:213
+#: lxc/list.go:559 lxc/storage_volume.go:1484 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1058 lxc/remote.go:734
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:837
+#: lxc/info.go:569 lxc/network.go:836
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:838
+#: lxc/info.go:570 lxc/network.go:837
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -3899,52 +3889,52 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:49 lxc/action.go:50
+#: lxc/action.go:48 lxc/action.go:49
 msgid "Pause instances"
 msgstr ""
 
-#: lxc/copy.go:64
+#: lxc/copy.go:63
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:155
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:796
+#: lxc/cluster.go:795
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:214
+#: lxc/info.go:213
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:196
+#: lxc/info.go:195
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1083
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
-#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
-#: lxc/config_trust.go:316 lxc/image.go:458 lxc/network.go:684
-#: lxc/network_acl.go:583 lxc/network_forward.go:598
-#: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
-#: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
-#: lxc/project.go:317 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:986
-#: lxc/storage_volume.go:1018
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
+#: lxc/network_acl.go:582 lxc/network_forward.go:597
+#: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
+#: lxc/storage_bucket.go:1056 lxc/storage_volume.go:985
+#: lxc/storage_volume.go:1017
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3964,7 +3954,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:497
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -3974,125 +3964,125 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:98 lxc/info.go:184
+#: lxc/info.go:97 lxc/info.go:183
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:150
+#: lxc/profile.go:149
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:347
+#: lxc/profile.go:346
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:398
+#: lxc/profile.go:397
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:684
+#: lxc/profile.go:683
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:709
+#: lxc/profile.go:708
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:759
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:158
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:50
+#: lxc/copy.go:54 lxc/init.go:49
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:59
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:230
+#: lxc/profile.go:229
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:997
+#: lxc/image.go:996
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:994
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:142
+#: lxc/project.go:141
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:198
+#: lxc/project.go:197
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:550
+#: lxc/project.go:549
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:969
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1513
+#: lxc/image.go:1512
 msgid "Property not found"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:102
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:947
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:32 lxc/publish.go:33
+#: lxc/publish.go:31 lxc/publish.go:32
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:253
+#: lxc/publish.go:252
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:237 lxc/file.go:238
+#: lxc/file.go:236 lxc/file.go:237
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:409 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:748
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:459 lxc/file.go:460
+#: lxc/file.go:458 lxc/file.go:459
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:682 lxc/file.go:848
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4101,88 +4091,84 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:496 lxc/image.go:888 lxc/image.go:1422
+#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:827
+#: lxc/project.go:826
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:792
+#: lxc/storage_bucket.go:791
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:186
+#: lxc/cluster.go:185
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:292
+#: lxc/info.go:282 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:245 lxc/file.go:466
+#: lxc/file.go:244 lxc/file.go:465
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:337
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1338 lxc/image.go:1339
+#: lxc/image.go:1337 lxc/image.go:1338
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:379
+#: lxc/copy.go:378
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1367
+#: lxc/image.go:1366
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:782
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:734 lxc/remote.go:773 lxc/remote.go:845 lxc/remote.go:900
-#: lxc/remote.go:938
+#: lxc/project.go:733 lxc/remote.go:772 lxc/remote.go:844 lxc/remote.go:899
+#: lxc/remote.go:937
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:294
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:852
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:777 lxc/remote.go:849 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:848 lxc/remote.go:941
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:99
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/utils/cancel.go:59
-msgid "Remote operation canceled by user"
-msgstr ""
-
-#: lxc/info.go:284
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4192,39 +4178,39 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:440
+#: lxc/cluster_group.go:439
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:482 lxc/cluster.go:483
+#: lxc/cluster.go:481 lxc/cluster.go:482
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/network_zone.go:1209
+#: lxc/network_zone.go:1208
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:198 lxc/alias.go:199
+#: lxc/alias.go:197 lxc/alias.go:198
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:773 lxc/network_load_balancer.go:936
+#: lxc/network_forward.go:772 lxc/network_load_balancer.go:935
 msgid "Remove all ports that match"
 msgstr ""
 
-#: lxc/network_acl.go:850
+#: lxc/network_acl.go:849
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:772
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:772
+#: lxc/network_load_balancer.go:771
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: lxc/network_zone.go:1210
+#: lxc/network_zone.go:1209
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -4232,23 +4218,23 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:438
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/network_forward.go:771 lxc/network_forward.go:772
+#: lxc/network_forward.go:770 lxc/network_forward.go:771
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:934 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:934
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:649 lxc/profile.go:650
+#: lxc/profile.go:648 lxc/profile.go:649
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:824 lxc/remote.go:825
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4256,24 +4242,24 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: lxc/network_acl.go:848 lxc/network_acl.go:849
+#: lxc/network_acl.go:847 lxc/network_acl.go:848
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: lxc/config_trust.go:534 lxc/config_trust.go:535
+#: lxc/config_trust.go:533 lxc/config_trust.go:534
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:511
+#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:432 lxc/cluster.go:433
+#: lxc/cluster.go:431 lxc/cluster.go:432
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:147 lxc/alias.go:148 lxc/image_alias.go:255
-#: lxc/image_alias.go:256
+#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
 
@@ -4281,45 +4267,45 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:614 lxc/network_acl.go:615
+#: lxc/network_acl.go:613 lxc/network_acl.go:614
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1059 lxc/network.go:1060
+#: lxc/network.go:1058 lxc/network.go:1059
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:725 lxc/profile.go:726
+#: lxc/profile.go:724 lxc/profile.go:725
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:510 lxc/project.go:511
+#: lxc/project.go:509 lxc/project.go:510
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1600
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1599
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1677 lxc/storage_volume.go:1697
+#: lxc/storage_volume.go:1676 lxc/storage_volume.go:1696
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:122
+#: lxc/info.go:121
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:765 lxc/cluster.go:766
+#: lxc/cluster.go:764 lxc/cluster.go:765
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4327,22 +4313,22 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:496
+#: lxc/info.go:495
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:69
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:71
+#: lxc/action.go:70
 msgid ""
 "Restart instances\n"
 "\n"
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1150 lxc/cluster.go:1151
+#: lxc/cluster.go:1149 lxc/cluster.go:1150
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4357,16 +4343,16 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2032
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2031
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1207
+#: lxc/cluster.go:1206
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: lxc/config_trust.go:101
+#: lxc/config_trust.go:100
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -4374,91 +4360,91 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:359
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: lxc/config_trust.go:580 lxc/config_trust.go:581
+#: lxc/config_trust.go:579 lxc/config_trust.go:580
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:943
+#: lxc/cluster.go:942
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:815
+#: lxc/storage_bucket.go:814
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:113
+#: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/warning.go:214
+#: lxc/warning.go:213
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1060
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:570
+#: lxc/list.go:569
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:632
+#: lxc/storage.go:631
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1211
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:971
-#: lxc/network_peer.go:143 lxc/storage.go:637
+#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:970
+#: lxc/network_peer.go:142 lxc/storage.go:636
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:165 lxc/warning.go:215
+#: lxc/operation.go:164 lxc/warning.go:214
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:490
+#: lxc/project.go:489
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:489
+#: lxc/project.go:488
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: lxc/network.go:858
+#: lxc/network.go:857
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:817
+#: lxc/storage_bucket.go:816
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:873
+#: lxc/storage_bucket.go:872
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -4467,19 +4453,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:101
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:598
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:100
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -4488,11 +4474,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:351
+#: lxc/cluster.go:350
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:976
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4518,7 +4504,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1529 lxc/image.go:1530
+#: lxc/image.go:1528 lxc/image.go:1529
 msgid "Set image properties"
 msgstr ""
 
@@ -4535,11 +4521,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network_acl.go:396
+#: lxc/network_acl.go:395
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:397
+#: lxc/network_acl.go:396
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -4548,11 +4534,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1109
+#: lxc/network.go:1108
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1110
+#: lxc/network.go:1109
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -4561,11 +4547,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:382
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:383
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4574,11 +4560,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:384
+#: lxc/network_load_balancer.go:383
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:384
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -4587,11 +4573,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_peer.go:384
+#: lxc/network_peer.go:383
 msgid "Set network peer keys"
 msgstr ""
 
-#: lxc/network_peer.go:385
+#: lxc/network_peer.go:384
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -4600,11 +4586,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:339
+#: lxc/network_zone.go:338
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:340
+#: lxc/network_zone.go:339
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -4613,15 +4599,15 @@ msgid ""
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:898 lxc/network_zone.go:899
+#: lxc/network_zone.go:897 lxc/network_zone.go:898
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:774
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:776
+#: lxc/profile.go:775
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4630,11 +4616,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:565
+#: lxc/project.go:564
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:565
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -4643,11 +4629,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:516
+#: lxc/storage_bucket.go:515
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:517
+#: lxc/storage_bucket.go:516
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -4656,11 +4642,11 @@ msgid ""
 "    lxc storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:651
+#: lxc/storage.go:650
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:652
+#: lxc/storage.go:651
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -4669,11 +4655,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1713
+#: lxc/storage_volume.go:1712
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1714
+#: lxc/storage_volume.go:1713
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4682,23 +4668,23 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:918
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:468
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:469
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:467
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:974
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -4710,19 +4696,19 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:556 lxc/cluster_group.go:557
+#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: lxc/config_template.go:300 lxc/config_template.go:301
+#: lxc/config_template.go:299 lxc/config_template.go:300
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:206 lxc/cluster.go:207
+#: lxc/cluster.go:205 lxc/cluster.go:206
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:184 lxc/operation.go:185
+#: lxc/operation.go:183 lxc/operation.go:184
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -4734,7 +4720,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/image.go:1418 lxc/image.go:1419
+#: lxc/image.go:1417 lxc/image.go:1418
 msgid "Show image properties"
 msgstr ""
 
@@ -4746,7 +4732,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:33 lxc/info.go:34
+#: lxc/info.go:32 lxc/info.go:33
 msgid "Show instance or server information"
 msgstr ""
 
@@ -4758,71 +4744,71 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network_acl.go:165 lxc/network_acl.go:166
+#: lxc/network_acl.go:164 lxc/network_acl.go:165
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: lxc/network_acl.go:218 lxc/network_acl.go:219
+#: lxc/network_acl.go:217 lxc/network_acl.go:218
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1179 lxc/network.go:1180
+#: lxc/network.go:1178 lxc/network.go:1179
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:168
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:170
+#: lxc/network_load_balancer.go:168 lxc/network_load_balancer.go:169
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: lxc/network_peer.go:158 lxc/network_peer.go:159
+#: lxc/network_peer.go:157 lxc/network_peer.go:158
 msgid "Show network peer configurations"
 msgstr ""
 
-#: lxc/network_zone.go:156 lxc/network_zone.go:157
+#: lxc/network_zone.go:155 lxc/network_zone.go:156
 msgid "Show network zone configurations"
 msgstr ""
 
-#: lxc/network_zone.go:720
+#: lxc/network_zone.go:719
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: lxc/network_zone.go:721
+#: lxc/network_zone.go:720
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:834 lxc/profile.go:835
+#: lxc/profile.go:833 lxc/profile.go:834
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:654 lxc/project.go:655
+#: lxc/project.go:653 lxc/project.go:654
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:593 lxc/storage_bucket.go:594
+#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:593
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1087 lxc/storage_bucket.go:1088
+#: lxc/storage_bucket.go:1086 lxc/storage_bucket.go:1087
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: lxc/storage.go:725 lxc/storage.go:726
+#: lxc/storage.go:724 lxc/storage.go:725
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1801 lxc/storage_volume.go:1802
+#: lxc/storage_volume.go:1800 lxc/storage_volume.go:1801
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1137 lxc/storage_volume.go:1138
+#: lxc/storage_volume.go:1136 lxc/storage_volume.go:1137
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:628 lxc/remote.go:629
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -4830,114 +4816,114 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:45
+#: lxc/info.go:44
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:729
+#: lxc/storage.go:728
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:406
+#: lxc/storage.go:405
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: lxc/config_trust.go:651 lxc/config_trust.go:652
+#: lxc/config_trust.go:650 lxc/config_trust.go:651
 msgid "Show trust configurations"
 msgstr ""
 
-#: lxc/cluster.go:255 lxc/cluster.go:256
+#: lxc/cluster.go:254 lxc/cluster.go:255
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:884 lxc/image.go:885
+#: lxc/image.go:883 lxc/image.go:884
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:402 lxc/storage.go:403
+#: lxc/storage.go:401 lxc/storage.go:402
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:303 lxc/warning.go:304
+#: lxc/warning.go:302 lxc/warning.go:303
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:944
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:277 lxc/info.go:293
+#: lxc/info.go:276 lxc/info.go:292
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1934 lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1933 lxc/storage_volume.go:1934
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1764
+#: lxc/storage_volume.go:1763
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1256
+#: lxc/info.go:597 lxc/storage_volume.go:1255
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:360
+#: lxc/info.go:359
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:387
+#: lxc/action.go:386
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:988
+#: lxc/image.go:987
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:31
+#: lxc/action.go:29 lxc/action.go:30
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:79
+#: lxc/launch.go:78
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "State"
 msgstr ""
 
-#: lxc/network.go:820
+#: lxc/network.go:819
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:632
+#: lxc/info.go:631
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:465
+#: lxc/info.go:464
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:91 lxc/action.go:92
+#: lxc/action.go:90 lxc/action.go:91
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:38
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:142
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -4946,137 +4932,137 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:162
+#: lxc/storage_bucket.go:161
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:229
+#: lxc/storage_bucket.go:228
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:871
+#: lxc/storage_bucket.go:870
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:937
+#: lxc/storage_bucket.go:936
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
 
-#: lxc/storage.go:153
+#: lxc/storage.go:152
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:205
+#: lxc/storage.go:204
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:151
+#: lxc/storage.go:150
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:54 lxc/move.go:65
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:53 lxc/move.go:64
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:590
+#: lxc/storage_volume.go:589
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:666
+#: lxc/storage_volume.go:665
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:433
+#: lxc/storage_volume.go:432
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:437
+#: lxc/storage_volume.go:436
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:116
+#: lxc/action.go:115
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1102
+#: lxc/cluster.go:1101
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:206
+#: lxc/info.go:205
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:210
+#: lxc/info.go:209
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:537
+#: lxc/info.go:536
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:541
+#: lxc/info.go:540
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:707 lxc/project.go:708
+#: lxc/project.go:706 lxc/project.go:707
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:878 lxc/remote.go:879
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:131
+#: lxc/alias.go:130
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:927 lxc/config_trust.go:516
+#: lxc/cluster.go:926 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/config_trust.go:409 lxc/image.go:1063 lxc/image_alias.go:237
-#: lxc/list.go:572 lxc/network.go:965 lxc/network.go:1039 lxc/operation.go:163
-#: lxc/storage_volume.go:1465 lxc/warning.go:216
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
+#: lxc/list.go:571 lxc/network.go:964 lxc/network.go:1038 lxc/operation.go:162
+#: lxc/storage_volume.go:1464 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1328
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1327
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1013
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1007
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:168
+#: lxc/move.go:167
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:204
 msgid "The --mode flag can't be used with --storage"
 msgstr ""
 
-#: lxc/move.go:180
+#: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:221
+#: lxc/move.go:220
 msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
@@ -5084,15 +5070,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:172
+#: lxc/move.go:171
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:192
+#: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5100,7 +5086,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/network_acl.go:839 lxc/network_acl.go:961
+#: lxc/network_acl.go:838 lxc/network_acl.go:960
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -5108,17 +5094,17 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:111
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:433
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:334
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5137,32 +5123,32 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/info.go:345
+#: lxc/info.go:344
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:290
+#: lxc/move.go:289
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:477 lxc/network.go:562 lxc/storage_volume.go:741
-#: lxc/storage_volume.go:822
+#: lxc/network.go:476 lxc/network.go:561 lxc/storage_volume.go:740
+#: lxc/storage_volume.go:821
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:481 lxc/network.go:566
+#: lxc/network.go:480 lxc/network.go:565
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:84
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:620
+#: lxc/cluster.go:619
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:609
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5178,23 +5164,23 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:318
+#: lxc/info.go:317
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:128
+#: lxc/action.go:127
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:949
+#: lxc/image.go:948
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:435
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:434
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -5209,69 +5195,69 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:288 lxc/config.go:428 lxc/config.go:578 lxc/config.go:668
-#: lxc/copy.go:129 lxc/info.go:337 lxc/network.go:805 lxc/storage.go:435
+#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:804 lxc/storage.go:434
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1241
+#: lxc/storage_volume.go:1240
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:218
+#: lxc/info.go:217
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1571
+#: lxc/storage_volume.go:1570
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:157
+#: lxc/image.go:156
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:333
+#: lxc/storage_volume.go:332
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:57
+#: lxc/copy.go:56
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:63
+#: lxc/move.go:62
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:768
+#: lxc/image.go:767
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:337 lxc/move.go:308
+#: lxc/copy.go:336 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/network.go:845
+#: lxc/network.go:844
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:275 lxc/launch.go:111
+#: lxc/action.go:274 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:553
 msgid "Type"
 msgstr ""
 
-#: lxc/config_trust.go:104
+#: lxc/config_trust.go:103
 msgid "Type of certificate"
 msgstr ""
 
@@ -5281,69 +5267,69 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:821
-#: lxc/storage_volume.go:1226
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:820
+#: lxc/storage_volume.go:1225
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:472
+#: lxc/info.go:471
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:805
+#: lxc/project.go:804
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1062
+#: lxc/image.go:1061
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/remote.go:731
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:829 lxc/storage_volume.go:1470
+#: lxc/project.go:828 lxc/storage_volume.go:1469
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:970 lxc/network_acl.go:150 lxc/network_zone.go:141
-#: lxc/profile.go:635 lxc/project.go:494 lxc/storage.go:636
-#: lxc/storage_volume.go:1469
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
+#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/storage_volume.go:1468
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:217
+#: lxc/warning.go:216
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:133
+#: lxc/info.go:132
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:193
+#: lxc/file.go:192
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:212 lxc/remote.go:246
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
-#: lxc/config_trust.go:120
+#: lxc/config_trust.go:119
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1234
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1503
-#: lxc/warning.go:244
+#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1502
+#: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5353,12 +5339,12 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:788
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/network_acl.go:776 lxc/network_acl.go:895
+#: lxc/network_acl.go:775 lxc/network_acl.go:894
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -5368,11 +5354,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:403
+#: lxc/cluster.go:402
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:60
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -5380,7 +5366,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1585 lxc/image.go:1586
+#: lxc/image.go:1584 lxc/image.go:1585
 msgid "Unset image properties"
 msgstr ""
 
@@ -5388,100 +5374,100 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network_acl.go:456 lxc/network_acl.go:457
+#: lxc/network_acl.go:455 lxc/network_acl.go:456
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1241 lxc/network.go:1242
+#: lxc/network.go:1240 lxc/network.go:1241
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:460
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:461
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:462
+#: lxc/network_load_balancer.go:461
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:463
+#: lxc/network_load_balancer.go:462
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: lxc/network_peer.go:453
+#: lxc/network_peer.go:452
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: lxc/network_peer.go:454
+#: lxc/network_peer.go:453
 msgid "Unset network peer keys"
 msgstr ""
 
-#: lxc/network_zone.go:399 lxc/network_zone.go:400
+#: lxc/network_zone.go:398 lxc/network_zone.go:399
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: lxc/network_zone.go:954 lxc/network_zone.go:955
+#: lxc/network_zone.go:953 lxc/network_zone.go:954
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:888 lxc/profile.go:889
+#: lxc/profile.go:887 lxc/profile.go:888
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:625 lxc/project.go:626
+#: lxc/project.go:624 lxc/project.go:625
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:660 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:659 lxc/storage_bucket.go:660
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage.go:809 lxc/storage.go:810
+#: lxc/storage.go:808 lxc/storage.go:809
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1901
+#: lxc/storage_volume.go:1899 lxc/storage_volume.go:1900
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/info.go:703
+#: lxc/info.go:702
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: lxc/network.go:846
+#: lxc/network.go:845
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1021
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1024
+#: lxc/cluster.go:1023
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:955
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/network.go:862
+#: lxc/network.go:861
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1239
+#: lxc/storage_volume.go:1238
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2104
+#: lxc/export.go:41 lxc/storage_volume.go:2103
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5490,7 +5476,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5499,52 +5485,52 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:514 lxc/delete.go:48
+#: lxc/cluster.go:513 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:67 lxc/utils/cancel.go:65
+#: lxc/file.go:66
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:141 lxc/info.go:250
+#: lxc/info.go:140 lxc/info.go:249
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: lxc/network.go:870
+#: lxc/network.go:869
 msgid "VLAN ID"
 msgstr ""
 
-#: lxc/network.go:861
+#: lxc/network.go:860
 msgid "VLAN filtering"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:867
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:300
+#: lxc/info.go:299
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:94 lxc/info.go:180
+#: lxc/info.go:93 lxc/info.go:179
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:239
+#: lxc/info.go:238
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1330
+#: lxc/storage_volume.go:1329
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:280
+#: lxc/info.go:279
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -5553,7 +5539,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:39
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -5567,9 +5553,9 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:943 lxc/operation.go:148 lxc/project.go:446
-#: lxc/project.go:451 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466
-#: lxc/project.go:471 lxc/remote.go:688 lxc/remote.go:693 lxc/remote.go:698
+#: lxc/network.go:942 lxc/operation.go:147 lxc/project.go:445
+#: lxc/project.go:450 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465
+#: lxc/project.go:470 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -5581,76 +5567,76 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:90
+#: lxc/copy.go:89
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:85 lxc/move.go:274 lxc/move.go:350 lxc/move.go:402
+#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:763
+#: lxc/storage_volume.go:762
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:237
+#: lxc/storage_volume.go:236
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:120 lxc/cluster.go:840 lxc/cluster_group.go:365
-#: lxc/config_trust.go:348 lxc/config_trust.go:431 lxc/monitor.go:31
-#: lxc/network.go:893 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:395
-#: lxc/storage.go:572 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1020
+#: lxc/cluster.go:1019
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:564 lxc/config_trust.go:579
+#: lxc/cluster.go:563 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/config_trust.go:86
+#: lxc/config_trust.go:85
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/list.go:47
+#: lxc/image.go:1016 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:150
+#: lxc/image_alias.go:149
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:164 lxc/network_acl.go:217 lxc/network_acl.go:482
-#: lxc/network_acl.go:661
+#: lxc/network_acl.go:163 lxc/network_acl.go:216 lxc/network_acl.go:481
+#: lxc/network_acl.go:660
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:726 lxc/network_acl.go:847
+#: lxc/network_acl.go:725 lxc/network_acl.go:846
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:263 lxc/network_acl.go:455
+#: lxc/network_acl.go:262 lxc/network_acl.go:454
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: lxc/network_acl.go:395
+#: lxc/network_acl.go:394
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:612
+#: lxc/network_acl.go:611
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: lxc/network_acl.go:312
+#: lxc/network_acl.go:311
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -5658,81 +5644,81 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: lxc/network_zone.go:155 lxc/network_zone.go:425 lxc/network_zone.go:543
+#: lxc/network_zone.go:154 lxc/network_zone.go:424 lxc/network_zone.go:542
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: lxc/network_zone.go:208 lxc/network_zone.go:398
+#: lxc/network_zone.go:207 lxc/network_zone.go:397
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:338
+#: lxc/network_zone.go:337
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:257
+#: lxc/network_zone.go:256
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:105
+#: lxc/image_alias.go:104
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: lxc/image_alias.go:59
+#: lxc/image_alias.go:58
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:253
+#: lxc/image_alias.go:252
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:649
+#: lxc/cluster.go:648
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
-#: lxc/config_trust.go:235 lxc/config_trust.go:532 lxc/config_trust.go:650
+#: lxc/config_trust.go:234 lxc/config_trust.go:531 lxc/config_trust.go:649
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:202 lxc/cluster_group.go:253
-#: lxc/cluster_group.go:555
+#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
+#: lxc/cluster_group.go:554
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:508
+#: lxc/cluster_group.go:507
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:883 lxc/image.go:1417
+#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1584
+#: lxc/image.go:1475 lxc/image.go:1583
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1528
+#: lxc/image.go:1527
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:143
+#: lxc/image.go:142
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/init.go:39 lxc/launch.go:23
+#: lxc/init.go:38 lxc/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:488
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:310 lxc/image.go:1337
+#: lxc/image.go:309 lxc/image.go:1336
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:239 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -5756,11 +5742,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:648
+#: lxc/profile.go:101 lxc/profile.go:647
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:164
+#: lxc/profile.go:163
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5768,8 +5754,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: lxc/config_template.go:66 lxc/config_template.go:108
-#: lxc/config_template.go:151 lxc/config_template.go:299
+#: lxc/config_template.go:65 lxc/config_template.go:107
+#: lxc/config_template.go:150 lxc/config_template.go:298
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -5777,7 +5763,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:48 lxc/action.go:69 lxc/action.go:90
+#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5785,24 +5771,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:29
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:166
+#: lxc/file.go:165
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:116
+#: lxc/file.go:115
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:236
+#: lxc/file.go:235
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:965
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -5810,11 +5796,11 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:31
+#: lxc/publish.go:30
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:33
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -5823,24 +5809,24 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:942
-#: lxc/cluster.go:1128 lxc/cluster.go:1149
+#: lxc/cluster.go:204 lxc/cluster.go:253 lxc/cluster.go:479 lxc/cluster.go:941
+#: lxc/cluster.go:1127 lxc/cluster.go:1148
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:76 lxc/cluster_group.go:438
+#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:303 lxc/cluster.go:402
+#: lxc/cluster.go:302 lxc/cluster.go:401
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:349
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:430
+#: lxc/cluster.go:429
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -5848,220 +5834,220 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network.go:587 lxc/network.go:771 lxc/network.go:987
-#: lxc/network.go:1178 lxc/network_forward.go:84
-#: lxc/network_load_balancer.go:88 lxc/network_peer.go:79
+#: lxc/network.go:365 lxc/network.go:586 lxc/network.go:770 lxc/network.go:986
+#: lxc/network.go:1177 lxc/network_forward.go:83
+#: lxc/network_load_balancer.go:87 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:417
+#: lxc/network.go:416
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:130
+#: lxc/network.go:129
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:713 lxc/network.go:1240
+#: lxc/network.go:712 lxc/network.go:1239
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1108
+#: lxc/network.go:1107
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:166 lxc/network_forward.go:486
-#: lxc/network_forward.go:627 lxc/network_load_balancer.go:168
-#: lxc/network_load_balancer.go:488 lxc/network_load_balancer.go:630
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:626 lxc/network_load_balancer.go:167
+#: lxc/network_load_balancer.go:487 lxc/network_load_balancer.go:629
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:771
+#: lxc/network_load_balancer.go:770
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:706
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:326 lxc/network_forward.go:459
-#: lxc/network_load_balancer.go:328 lxc/network_load_balancer.go:461
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
+#: lxc/network_load_balancer.go:327 lxc/network_load_balancer.go:460
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:381 lxc/network_load_balancer.go:383
+#: lxc/network_forward.go:380 lxc/network_load_balancer.go:382
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:872
+#: lxc/network_load_balancer.go:871
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:705
+#: lxc/network_forward.go:704
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:770 lxc/network_load_balancer.go:933
+#: lxc/network_forward.go:769 lxc/network_load_balancer.go:932
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:230 lxc/network_load_balancer.go:232
+#: lxc/network_forward.go:229 lxc/network_load_balancer.go:231
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: lxc/network.go:1057
+#: lxc/network.go:1056
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network_peer.go:157
+#: lxc/network_peer.go:156
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: lxc/network_peer.go:479 lxc/network_peer.go:603
+#: lxc/network_peer.go:478 lxc/network_peer.go:602
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: lxc/network_peer.go:214
+#: lxc/network_peer.go:213
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 msgstr ""
 
-#: lxc/network_peer.go:328 lxc/network_peer.go:452
+#: lxc/network_peer.go:327 lxc/network_peer.go:451
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: lxc/network_peer.go:383
+#: lxc/network_peer.go:382
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:502
+#: lxc/network.go:501
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:215
+#: lxc/network.go:214
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:288
+#: lxc/network.go:287
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:183
+#: lxc/operation.go:52 lxc/operation.go:182
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:168 lxc/storage.go:219 lxc/storage.go:401 lxc/storage.go:724
-#: lxc/storage_bucket.go:438
+#: lxc/storage.go:167 lxc/storage.go:218 lxc/storage.go:400 lxc/storage.go:723
+#: lxc/storage_bucket.go:437
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2241
+#: lxc/storage_volume.go:2240
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:181 lxc/storage_bucket.go:243
-#: lxc/storage_bucket.go:592 lxc/storage_bucket.go:729
+#: lxc/storage_bucket.go:180 lxc/storage_bucket.go:242
+#: lxc/storage_bucket.go:591 lxc/storage_bucket.go:728
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:374 lxc/storage_bucket.go:659
-#: lxc/storage_bucket.go:809 lxc/storage_bucket.go:887
-#: lxc/storage_bucket.go:951 lxc/storage_bucket.go:1086
+#: lxc/storage_bucket.go:373 lxc/storage_bucket.go:658
+#: lxc/storage_bucket.go:808 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:950 lxc/storage_bucket.go:1085
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:515
+#: lxc/storage_bucket.go:514
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:82
+#: lxc/storage_bucket.go:81
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:95
+#: lxc/storage.go:94
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:341 lxc/storage.go:808
+#: lxc/storage.go:340 lxc/storage.go:807
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: lxc/storage.go:650
+#: lxc/storage.go:649
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1598
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1136
+#: lxc/storage_volume.go:1135
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:681
+#: lxc/storage_volume.go:680
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:162
+#: lxc/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1899
+#: lxc/storage_volume.go:1898
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1712
+#: lxc/storage_volume.go:1711
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2030
+#: lxc/storage_volume.go:2029
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2096
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1933
+#: lxc/storage_volume.go:1932
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:527
+#: lxc/storage_volume.go:526
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:605 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1800
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:843
+#: lxc/storage_volume.go:1799
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1048
+#: lxc/storage_volume.go:1047
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1355
+#: lxc/storage_volume.go:1354
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1564
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:327
+#: lxc/storage_volume.go:326
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:308
-#: lxc/profile.go:361 lxc/profile.go:412 lxc/profile.go:833
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
+#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6077,11 +6063,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:887
+#: lxc/profile.go:537 lxc/profile.go:886
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:773
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6089,60 +6075,60 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:723
+#: lxc/profile.go:722
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:246
+#: lxc/profile.go:245
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:156 lxc/project.go:220 lxc/project.go:653
-#: lxc/project.go:706
+#: lxc/project.go:91 lxc/project.go:155 lxc/project.go:219 lxc/project.go:652
+#: lxc/project.go:705
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:346 lxc/project.go:624 lxc/project.go:765
+#: lxc/project.go:345 lxc/project.go:623 lxc/project.go:764
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:564
+#: lxc/project.go:563
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:507
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: lxc/copy.go:38
+#: lxc/copy.go:37
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: lxc/network_zone.go:648
+#: lxc/network_zone.go:647
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: lxc/network_zone.go:719 lxc/network_zone.go:980 lxc/network_zone.go:1097
+#: lxc/network_zone.go:718 lxc/network_zone.go:979 lxc/network_zone.go:1096
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: lxc/network_zone.go:769 lxc/network_zone.go:953
+#: lxc/network_zone.go:768 lxc/network_zone.go:952
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: lxc/network_zone.go:897
+#: lxc/network_zone.go:896
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_zone.go:1162 lxc/network_zone.go:1208
+#: lxc/network_zone.go:1161 lxc/network_zone.go:1207
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: lxc/network_zone.go:817
+#: lxc/network_zone.go:816
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -6150,7 +6136,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:32
+#: lxc/info.go:31
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -6162,68 +6148,68 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:86
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:763
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:476 lxc/remote.go:721
+#: lxc/project.go:475 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
-#: lxc/storage.go:461
+#: lxc/storage.go:460
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:933
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:460
+#: lxc/storage.go:459
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:936
+#: lxc/image.go:935
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:379
+#: lxc/action.go:378
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/storage.go:458
+#: lxc/storage.go:457
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:59
+#: lxc/alias.go:58
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:201
+#: lxc/alias.go:200
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:150
+#: lxc/alias.go:149
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:653
+#: lxc/cluster.go:652
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:81
+#: lxc/cluster_group.go:80
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6261,32 +6247,32 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:33
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:969
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:239
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:462
+#: lxc/file.go:461
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:366
+#: lxc/image.go:365
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -6295,13 +6281,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:31
+#: lxc/import.go:30
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:36
+#: lxc/info.go:35
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -6310,7 +6296,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:42
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -6318,7 +6304,7 @@ msgid ""
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/launch.go:27
+#: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
 "\n"
@@ -6333,7 +6319,7 @@ msgid ""
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
-#: lxc/list.go:123
+#: lxc/list.go:122
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -6359,7 +6345,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:47
+#: lxc/move.go:46
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"
@@ -6373,7 +6359,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/network.go:291
+#: lxc/network.go:290
 msgid ""
 "lxc network create foo\n"
 "    Create a new network called foo\n"
@@ -6382,13 +6368,13 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: lxc/operation.go:187
+#: lxc/operation.go:186
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:169
+#: lxc/profile.go:168
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6411,13 +6397,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:416
+#: lxc/profile.go:415
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:224
+#: lxc/project.go:223
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -6444,74 +6430,74 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:246
+#: lxc/storage_bucket.go:245
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:954
+#: lxc/storage_bucket.go:953
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1089
+#: lxc/storage_bucket.go:1088
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:595
+#: lxc/storage_bucket.go:594
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: lxc/storage.go:223
+#: lxc/storage.go:222
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:848
+#: lxc/storage_volume.go:847
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2244
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1804
+#: lxc/storage_volume.go:1803
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
-#: lxc/storage.go:459
+#: lxc/storage.go:458
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:924 lxc/image.go:929 lxc/image.go:1119
+#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6519,24 +6505,24 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/storage.go:463
+#: lxc/storage.go:462
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1123
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1082
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1035
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: lxc/storage.go:462
+#: lxc/storage.go:461
 msgid "total space"
 msgstr ""
 
@@ -6544,15 +6530,15 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: lxc/storage.go:457
+#: lxc/storage.go:456
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
-#: lxc/image.go:1116
+#: lxc/cluster.go:512 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
+#: lxc/image.go:1115
 msgid "yes"
 msgstr ""

--- a/shared/cmd/cancel.go
+++ b/shared/cmd/cancel.go
@@ -1,4 +1,4 @@
-package utils
+package cmd
 
 import (
 	"fmt"

--- a/shared/cmd/progress.go
+++ b/shared/cmd/progress.go
@@ -1,4 +1,4 @@
-package utils
+package cmd
 
 import (
 	"fmt"

--- a/shared/cmd/sort.go
+++ b/shared/cmd/sort.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/fvbommel/sortorder"
@@ -96,4 +98,84 @@ func (a ByNameAndType) Less(i, j int) bool {
 	}
 
 	return sortorder.NaturalLess(a[i][1], a[j][1])
+}
+
+// SortByPrecedence sorts the given data in order of precedence. Each row of the data argument should have length equal
+// to len(displayColumns). The sortColumns argument should be a subset of displayColumns.
+func SortByPrecedence(data [][]string, displayColumns string, sortColumns string) error {
+	precedence := make([]int, len(sortColumns))
+	for i, r := range sortColumns {
+		index := strings.IndexRune(displayColumns, r)
+		if index < 0 {
+			return fmt.Errorf("Invalid sort column %q, not present in display columns %q", string(r), displayColumns)
+		}
+
+		for _, row := range data {
+			if index >= len(row) {
+				return fmt.Errorf("Index of sort column %q outside data range", string(r))
+			}
+		}
+
+		precedence[i] = index
+	}
+
+	sort.Sort(byPrecedence{
+		precedence: precedence,
+		data:       data,
+	})
+
+	return nil
+}
+
+// byPrecedence implements the sort.Interface. It is intentionally private because it may panic. Use the
+// SortByPrecedence method instead.
+type byPrecedence struct {
+	// precedence defines the column indexes to be sorted in order of precedence.
+	precedence []int
+	// data is the table data to be sorted.
+	data [][]string
+}
+
+func (a byPrecedence) Len() int {
+	if a.data == nil {
+		return 0
+	}
+
+	return len(a.data)
+}
+
+func (a byPrecedence) Swap(i, j int) {
+	if a.data == nil {
+		return
+	}
+
+	a.data[i], a.data[j] = a.data[j], a.data[i]
+}
+
+func (a byPrecedence) Less(i, j int) bool {
+	for _, k := range a.precedence {
+		if k >= len(a.data[i]) {
+			panic("Given precedence index is out of bounds")
+		}
+
+		if k >= len(a.data[j]) {
+			panic("Given precedence index is out of bounds")
+		}
+
+		if a.data[i][k] == a.data[j][k] {
+			continue
+		}
+
+		if a.data[i][k] == "" {
+			return false
+		}
+
+		if a.data[j][k] == "" {
+			return true
+		}
+
+		return sortorder.NaturalLess(a.data[i][k], a.data[j][k])
+	}
+
+	return false
 }

--- a/shared/cmd/sort.go
+++ b/shared/cmd/sort.go
@@ -1,4 +1,4 @@
-package utils
+package cmd
 
 import (
 	"strings"

--- a/shared/cmd/sort_test.go
+++ b/shared/cmd/sort_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type sortSuite struct {
+	suite.Suite
+}
+
+func TestSortSuite(t *testing.T) {
+	suite.Run(t, new(sortSuite))
+}
+
+// stringList can be used to sort a list of strings.
+func (s *sortSuite) Test_stringList() {
+	data := [][]string{{"foo", "bar"}, {"baz", "bza"}}
+	sort.Sort(StringList(data))
+	s.Equal([][]string{{"baz", "bza"}, {"foo", "bar"}}, data)
+}
+
+// The first different string is used in sorting.
+func (s *sortSuite) Test_stringList_sort_by_column() {
+	data := [][]string{{"foo", "baz"}, {"foo", "bar"}}
+	sort.Sort(StringList(data))
+	s.Equal([][]string{{"foo", "bar"}, {"foo", "baz"}}, data)
+}
+
+// Empty strings are sorted last.
+func (s *sortSuite) Test_stringList_empty_strings() {
+	data := [][]string{{"", "bar"}, {"foo", "baz"}}
+	sort.Sort(StringList(data))
+	s.Equal([][]string{{"foo", "baz"}, {"", "bar"}}, data)
+}

--- a/shared/cmd/sort_test.go
+++ b/shared/cmd/sort_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -34,4 +35,134 @@ func (s *sortSuite) Test_stringList_empty_strings() {
 	data := [][]string{{"", "bar"}, {"foo", "baz"}}
 	sort.Sort(StringList(data))
 	s.Equal([][]string{{"foo", "baz"}, {"", "bar"}}, data)
+}
+
+func (s *sortSuite) TestSortByPrecedence() {
+	type args struct {
+		data           [][]string
+		displayColumns string
+		sortColumns    string
+	}
+
+	tests := []struct {
+		name      string
+		args      args
+		expect    [][]string
+		expectErr error
+	}{
+		{
+			name: "Sort column not in display columns",
+			args: args{
+				data: [][]string{
+					{"b", "b", "c"},
+					{"a", "b", "c"},
+					{"c", "b", "a"},
+				},
+				displayColumns: "123",
+				sortColumns:    "234",
+			},
+			expect: [][]string{
+				{"b", "b", "c"},
+				{"a", "b", "c"},
+				{"c", "b", "a"},
+			},
+			expectErr: fmt.Errorf("Invalid sort column \"4\", not present in display columns \"123\""),
+		},
+		{
+			name: "Sort column outside data range",
+			args: args{
+				data: [][]string{
+					{"b", "b", "c", "d"},
+					{"a", "b", "c", "d"},
+					// Third row is shorter, so sort column "4" is outside the range.
+					{"c", "b", "a"},
+				},
+				displayColumns: "1234",
+				sortColumns:    "4",
+			},
+			expect: [][]string{
+				{"b", "b", "c", "d"},
+				{"a", "b", "c", "d"},
+				{"c", "b", "a"},
+			},
+			expectErr: fmt.Errorf("Index of sort column \"4\" outside data range"),
+		},
+		{
+			name: "Sort by first column",
+			args: args{
+				data: [][]string{
+					{"b", "b", "c"},
+					{"a", "b", "c"},
+					{"c", "b", "a"},
+				},
+				displayColumns: "123",
+				sortColumns:    "1",
+			},
+			expect: [][]string{
+				{"a", "b", "c"},
+				{"b", "b", "c"},
+				{"c", "b", "a"},
+			},
+		},
+		{
+			name: "Sort by second column",
+			args: args{
+				data: [][]string{
+					{"b", "b", "c"},
+					{"a", "b", "c"},
+					{"c", "b", "a"},
+				},
+				displayColumns: "123",
+				sortColumns:    "2",
+			},
+			// Expect no change because column 2 is already in order
+			expect: [][]string{
+				{"b", "b", "c"},
+				{"a", "b", "c"},
+				{"c", "b", "a"},
+			},
+		},
+		{
+			name: "Sort by third column",
+			args: args{
+				data: [][]string{
+					{"b", "b", "c"},
+					{"a", "b", "c"},
+					{"c", "b", "a"},
+				},
+				displayColumns: "123",
+				sortColumns:    "3",
+			},
+			expect: [][]string{
+				{"c", "b", "a"},
+				{"b", "b", "c"},
+				{"a", "b", "c"},
+			},
+		},
+		{
+			name: "Sort by third and first columns",
+			args: args{
+				data: [][]string{
+					{"b", "b", "c"},
+					{"a", "b", "c"},
+					{"c", "b", "a"},
+				},
+				displayColumns: "123",
+				sortColumns:    "31",
+			},
+			expect: [][]string{
+				{"c", "b", "a"},
+				{"a", "b", "c"},
+				{"b", "b", "c"},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		s.T().Logf("Case %d: %s", i, test.name)
+
+		err := SortByPrecedence(test.args.data, test.args.displayColumns, test.args.sortColumns)
+		s.Equal(test.expectErr, err)
+		s.Equal(test.expect, test.args.data)
+	}
 }

--- a/shared/cmd/table.go
+++ b/shared/cmd/table.go
@@ -1,4 +1,4 @@
-package utils
+package cmd
 
 import (
 	"encoding/csv"

--- a/shared/cmd/table_test.go
+++ b/shared/cmd/table_test.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/lxc/lxd/shared/api"
+)
+
+type tableSuite struct {
+	suite.Suite
+}
+
+func TestTableSuite(t *testing.T) {
+	suite.Run(t, new(tableSuite))
+}
+
+func (s *tableSuite) TestRenderSlice() {
+	type TestDataType struct {
+		SomeString  string   `json:"some_string" yaml:"some_string"`
+		SomeInteger int      `json:"some_integer" yaml:"some_integer"`
+		SomeURL     *api.URL `json:"some_url" yaml:"some_url"`
+	}
+
+	testDataTypeColumnMap := map[rune]Column{
+		's': {
+			Header: "Some String",
+			DataFunc: func(a any) (string, error) {
+				return a.(TestDataType).SomeString, nil
+			},
+		},
+		'i': {
+			Header: "Some Integer",
+			DataFunc: func(a any) (string, error) {
+				return strconv.Itoa(a.(TestDataType).SomeInteger), nil
+			},
+		},
+		'u': {
+			Header: "Some URL",
+			DataFunc: func(a any) (string, error) {
+				return a.(TestDataType).SomeURL.String(), nil
+			},
+		},
+	}
+
+	testDataTypeSlice := []TestDataType{
+		{
+			SomeString:  "foo",
+			SomeInteger: 1,
+			SomeURL:     api.NewURL().Path("1.0", "instances", "foo"),
+		},
+		{
+			SomeString:  "fizz",
+			SomeInteger: 3,
+			SomeURL:     api.NewURL().Path("1.0", "instances", "fizz"),
+		},
+		{
+			SomeString:  "buzz",
+			SomeInteger: 4,
+			SomeURL:     api.NewURL().Path("1.0", "instances", "buzz"),
+		},
+		{
+			SomeString:  "bar",
+			SomeInteger: 2,
+			SomeURL:     api.NewURL().Path("1.0", "instances", "bar"),
+		},
+	}
+
+	type args struct {
+		data           any
+		format         string
+		displayColumns string
+		sortColumns    string
+		columnMap      map[rune]Column
+	}
+
+	tests := []struct {
+		name      string
+		args      args
+		expect    string
+		expectErr error
+	}{
+		{
+			name: "Incorrect data type (must be slice)",
+			args: args{
+				data: TestDataType{
+					SomeString:  "hello",
+					SomeInteger: 3,
+					SomeURL:     api.NewURL().Host("example.com"),
+				},
+				format: TableFormatCSV,
+			},
+			expect:    "",
+			expectErr: fmt.Errorf("Cannot render table: %w", fmt.Errorf("Provided argument is not a slice")),
+		},
+		{
+			name: "Invalid format",
+			args: args{
+				data:   testDataTypeSlice,
+				format: "not a table format",
+			},
+			expect:    "",
+			expectErr: fmt.Errorf("Invalid format \"not a table format\""),
+		},
+		{
+			name: "happy path - csv, display all, sort precedence string->integer->url",
+			args: args{
+				data:           testDataTypeSlice,
+				format:         TableFormatCSV,
+				displayColumns: "siu",
+				sortColumns:    "siu",
+				columnMap:      testDataTypeColumnMap,
+			},
+			expect: `bar,2,/1.0/instances/bar
+buzz,4,/1.0/instances/buzz
+fizz,3,/1.0/instances/fizz
+foo,1,/1.0/instances/foo
+`,
+			expectErr: nil,
+		},
+		{
+			name: "happy path - compact, display string+integer, sort by integer",
+			args: args{
+				data:           testDataTypeSlice,
+				format:         TableFormatCompact,
+				displayColumns: "si",
+				sortColumns:    "i",
+				columnMap:      testDataTypeColumnMap,
+			},
+			expect: `  SOME STRING  SOME INTEGER  
+  foo          1             
+  bar          2             
+  fizz         3             
+  buzz         4             
+`,
+			expectErr: nil,
+		},
+		{
+			name: "happy path - table, display all, do not sort",
+			args: args{
+				data:           testDataTypeSlice,
+				format:         TableFormatTable,
+				displayColumns: "siu",
+				sortColumns:    "",
+				columnMap:      testDataTypeColumnMap,
+			},
+			expect: `+-------------+--------------+---------------------+
+| SOME STRING | SOME INTEGER |      SOME URL       |
++-------------+--------------+---------------------+
+| foo         | 1            | /1.0/instances/foo  |
++-------------+--------------+---------------------+
+| fizz        | 3            | /1.0/instances/fizz |
++-------------+--------------+---------------------+
+| buzz        | 4            | /1.0/instances/buzz |
++-------------+--------------+---------------------+
+| bar         | 2            | /1.0/instances/bar  |
++-------------+--------------+---------------------+
+`,
+			expectErr: nil,
+		},
+	}
+
+	for i, test := range tests {
+		s.T().Logf("Test %d: %s", i, test.name)
+
+		// Set up a pipe to read from stdout.
+		stdout := os.Stdout
+		r, w, err := os.Pipe()
+		s.Require().NoError(err)
+		os.Stdout = w
+
+		// Call method but fix stdout before making any assertions.
+		actualErr := RenderSlice(test.args.data, test.args.format, test.args.displayColumns, test.args.sortColumns, test.args.columnMap)
+
+		// Restore stdout and close the writer now so that io.Copy gets an io.EOF and doesn't block indefinitely.
+		os.Stdout = stdout
+		err = w.Close()
+		s.Require().NoError(err)
+
+		// Read what was printed to stdout.
+		buffer := bytes.NewBuffer(nil)
+		_, err = io.Copy(buffer, r)
+		s.Require().NoError(err)
+		output := buffer.String()
+
+		// Make assertions
+		s.Equal(test.expectErr, actualErr)
+		s.Equal(test.expect, output)
+	}
+}


### PR DESCRIPTION
This PR moves all[^1] CLI related utils into a single package under `shared/cmd`. Additionally, some useful generic methods for table rendering and sorting (see https://github.com/canonical/lxd-cloud/pull/291 and https://github.com/canonical/lxd-cloud/pull/292) have also been moved from LXD Cloud into `shared/cmd`.

Follow up PRs may use the new method `RenderSlice` to allow the user to specify column sort order precedence via a `--sort` flag or similar.

[^1]: There are still some utils in `lxc/utils.go`, but these are not used outside of the `lxc` package.