### PR TITLE
Allow the consistent selection of a GPU device by DRM ID

### DIFF
--- a/doc/reference/devices_gpu.md
+++ b/doc/reference/devices_gpu.md
@@ -38,7 +38,7 @@ GPU devices of type `physical` have the following device options:
 Key         | Type      | Default           | Description
 :--         | :--       | :--               | :--
 `gid`       | int       | `0`               | GID of the device owner in the instance (container only)
-`id`        | string    | -                 | The card ID of the GPU device
+`id`        | string    | -                 | The DRM card ID of the GPU device
 `mode`      | int       | `0660`            | Mode of the device in the instance (container only)
 `pci`       | string    | -                 | The PCI address of the GPU device
 `productid` | string    | -                 | The product ID of the GPU device
@@ -62,7 +62,7 @@ GPU devices of type `mdev` have the following device options:
 
 Key         | Type      | Default           | Description
 :--         | :--       | :--               | :--
-`id`        | string    | -                 | The card ID of the GPU device
+`id`        | string    | -                 | The DRM card ID of the GPU device
 `mdev`      | string    | -                 | The `mdev` profile to use (required - for example, `i915-GVTg_V5_4`)
 `pci`       | string    | -                 | The PCI address of the GPU device
 `productid` | string    | -                 | The product ID of the GPU device
@@ -85,7 +85,7 @@ GPU devices of type `mig` have the following device options:
 
 Key         | Type      | Default           | Description
 :--         | :--       | :--               | :--
-`id`        | string    | -                 | The card ID of the GPU device
+`id`        | string    | -                 | The DRM card ID of the GPU device
 `mig.ci`    | int       | -                 | Existing MIG compute instance ID
 `mig.gi`    | int       | -                 | Existing MIG GPU instance ID
 `mig.uuid`  | string    | -                 | Existing MIG device UUID (`MIG-` prefix can be omitted)
@@ -111,7 +111,7 @@ GPU devices of type `sriov` have the following device options:
 
 Key         | Type      | Default           | Description
 :--         | :--       | :--               | :--
-`id`         | string   | -                 | The card ID of the parent GPU device
+`id`         | string   | -                 | The DRM card ID of the parent GPU device
 `pci`        | string   | -                 | The PCI address of the parent GPU device
 `productid`  | string   | -                 | The product ID of the parent GPU device
 `vendorid`   | string   | -                 | The vendor ID of the parent GPU device

--- a/lxd/device/device_utils_generic.go
+++ b/lxd/device/device_utils_generic.go
@@ -12,8 +12,8 @@ func deviceJoinPath(parts ...string) string {
 	return strings.Join(parts, ".")
 }
 
-// validatePCIDevice returns whether a configured PCI device exists. It also returns true, if no device
-// has been specified.
+// validatePCIDevice returns whether a configured PCI device exists under the given address.
+// It also returns nil, if an empty address is supplied.
 func validatePCIDevice(address string) error {
 	if address != "" && !shared.PathExists(fmt.Sprintf("/sys/bus/pci/devices/%s", address)) {
 		return fmt.Errorf("Invalid PCI address (no device found): %s", address)

--- a/lxd/device/gpu.go
+++ b/lxd/device/gpu.go
@@ -1,6 +1,9 @@
 package device
 
 import (
+	"fmt"
+
+	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/validate"
 )
 
@@ -62,4 +65,13 @@ func gpuValidationRules(requiredFields []string, optionalFields []string) map[st
 	}
 
 	return validators
+}
+
+// Check if the device matches the given GPU card.
+// It matches based on vendorid, pci, productid or id settings of the device.
+func gpuSelected(dev *gpuPhysical, gpu api.ResourcesGPUCard) bool {
+	return !((dev.config["vendorid"] != "" && gpu.VendorID != dev.config["vendorid"]) ||
+		(dev.config["pci"] != "" && gpu.PCIAddress != dev.config["pci"]) ||
+		(dev.config["productid"] != "" && gpu.ProductID != dev.config["productid"]) ||
+		(dev.config["id"] != "" && (gpu.DRM == nil || fmt.Sprintf("%d", gpu.DRM.ID) != dev.config["id"])))
 }

--- a/lxd/device/gpu.go
+++ b/lxd/device/gpu.go
@@ -68,7 +68,7 @@ func gpuValidationRules(requiredFields []string, optionalFields []string) map[st
 }
 
 // Check if the device matches the given GPU card.
-// It matches based on vendorid, pci, productid or id settings of the device.
+// It matches based on vendorid, pci, productid or id setting of the device.
 func gpuSelected(dev *gpuPhysical, gpu api.ResourcesGPUCard) bool {
 	return !((dev.config["vendorid"] != "" && gpu.VendorID != dev.config["vendorid"]) ||
 		(dev.config["pci"] != "" && gpu.PCIAddress != dev.config["pci"]) ||

--- a/lxd/device/gpu.go
+++ b/lxd/device/gpu.go
@@ -3,6 +3,7 @@ package device
 import (
 	"fmt"
 
+	"github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/validate"
 )
@@ -69,9 +70,9 @@ func gpuValidationRules(requiredFields []string, optionalFields []string) map[st
 
 // Check if the device matches the given GPU card.
 // It matches based on vendorid, pci, productid or id setting of the device.
-func gpuSelected(dev *gpuPhysical, gpu api.ResourcesGPUCard) bool {
-	return !((dev.config["vendorid"] != "" && gpu.VendorID != dev.config["vendorid"]) ||
-		(dev.config["pci"] != "" && gpu.PCIAddress != dev.config["pci"]) ||
-		(dev.config["productid"] != "" && gpu.ProductID != dev.config["productid"]) ||
-		(dev.config["id"] != "" && (gpu.DRM == nil || fmt.Sprintf("%d", gpu.DRM.ID) != dev.config["id"])))
+func gpuSelected(device config.Device, gpu api.ResourcesGPUCard) bool {
+	return !((device["vendorid"] != "" && gpu.VendorID != device["vendorid"]) ||
+		(device["pci"] != "" && gpu.PCIAddress != device["pci"]) ||
+		(device["productid"] != "" && gpu.ProductID != device["productid"]) ||
+		(device["id"] != "" && (gpu.DRM == nil || fmt.Sprintf("%d", gpu.DRM.ID) != device["id"])))
 }

--- a/lxd/device/gpu_mdev.go
+++ b/lxd/device/gpu_mdev.go
@@ -226,7 +226,7 @@ func (d *gpuMdev) validateConfig(instConf instance.ConfigReader) error {
 	if d.config["pci"] != "" {
 		for _, field := range []string{"id", "productid", "vendorid"} {
 			if d.config[field] != "" {
-				return fmt.Errorf(`Cannot use %q when when "pci" is set`, field)
+				return fmt.Errorf(`Cannot use %q when "pci" is set`, field)
 			}
 		}
 
@@ -236,7 +236,7 @@ func (d *gpuMdev) validateConfig(instConf instance.ConfigReader) error {
 	if d.config["id"] != "" {
 		for _, field := range []string{"pci", "productid", "vendorid"} {
 			if d.config[field] != "" {
-				return fmt.Errorf(`Cannot use %q when when "id" is set`, field)
+				return fmt.Errorf(`Cannot use %q when "id" is set`, field)
 			}
 		}
 	}

--- a/lxd/device/gpu_mdev.go
+++ b/lxd/device/gpu_mdev.go
@@ -59,11 +59,8 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 
 	var pciAddress string
 	for _, gpu := range gpus.Cards {
-		// Skip any cards that don't match the vendorid, pci, productid or DRM ID settings (if specified).
-		if (d.config["vendorid"] != "" && gpu.VendorID != d.config["vendorid"]) ||
-			(d.config["pci"] != "" && gpu.PCIAddress != d.config["pci"]) ||
-			(d.config["productid"] != "" && gpu.ProductID != d.config["productid"]) ||
-			(d.config["id"] != "" && (gpu.DRM == nil || fmt.Sprintf("%d", gpu.DRM.ID) != d.config["id"])) {
+		// Skip any cards that are not selected.
+		if !gpuSelected(d.Config(), gpu) {
 			continue
 		}
 

--- a/lxd/device/gpu_mig.go
+++ b/lxd/device/gpu_mig.go
@@ -46,7 +46,7 @@ func (d *gpuMIG) validateConfig(instConf instance.ConfigReader) error {
 	if d.config["pci"] != "" {
 		for _, field := range []string{"id", "productid", "vendorid"} {
 			if d.config[field] != "" {
-				return fmt.Errorf(`Cannot use %q when when "pci" is set`, field)
+				return fmt.Errorf(`Cannot use %q when "pci" is set`, field)
 			}
 		}
 
@@ -56,7 +56,7 @@ func (d *gpuMIG) validateConfig(instConf instance.ConfigReader) error {
 	if d.config["id"] != "" {
 		for _, field := range []string{"pci", "productid", "vendorid"} {
 			if d.config[field] != "" {
-				return fmt.Errorf(`Cannot use %q when when "id" is set`, field)
+				return fmt.Errorf(`Cannot use %q when "id" is set`, field)
 			}
 		}
 	}

--- a/lxd/device/gpu_mig.go
+++ b/lxd/device/gpu_mig.go
@@ -119,10 +119,8 @@ func (d *gpuMIG) Start() (*deviceConfig.RunConfig, error) {
 
 	var pciAddress string
 	for _, gpu := range gpus.Cards {
-		// Skip any cards that don't match the vendorid, pci or productid settings (if specified).
-		if (d.config["vendorid"] != "" && gpu.VendorID != d.config["vendorid"]) ||
-			(d.config["pci"] != "" && gpu.PCIAddress != d.config["pci"]) ||
-			(d.config["productid"] != "" && gpu.ProductID != d.config["productid"]) {
+		// Skip any cards that are not selected.
+		if !gpuSelected(d.Config(), gpu) {
 			continue
 		}
 

--- a/lxd/device/gpu_physical.go
+++ b/lxd/device/gpu_physical.go
@@ -111,10 +111,8 @@ func (d *gpuPhysical) startContainer() (*deviceConfig.RunConfig, error) {
 	found := false
 
 	for _, gpu := range gpus.Cards {
-		// Skip any cards that don't match the vendorid, pci or productid settings (if specified).
-		if (d.config["vendorid"] != "" && gpu.VendorID != d.config["vendorid"]) ||
-			(d.config["pci"] != "" && gpu.PCIAddress != d.config["pci"]) ||
-			(d.config["productid"] != "" && gpu.ProductID != d.config["productid"]) {
+		// Skip any cards that are not selected
+		if !gpuSelected(d, gpu) {
 			continue
 		}
 

--- a/lxd/device/gpu_physical.go
+++ b/lxd/device/gpu_physical.go
@@ -112,7 +112,7 @@ func (d *gpuPhysical) startContainer() (*deviceConfig.RunConfig, error) {
 
 	for _, gpu := range gpus.Cards {
 		// Skip any cards that are not selected.
-		if !gpuSelected(d, gpu) {
+		if !gpuSelected(d.Config(), gpu) {
 			continue
 		}
 
@@ -219,7 +219,7 @@ func (d *gpuPhysical) startVM() (*deviceConfig.RunConfig, error) {
 
 	for _, gpu := range gpus.Cards {
 		// Skip any cards that are not selected.
-		if !gpuSelected(d, gpu) {
+		if !gpuSelected(d.Config(), gpu) {
 			continue
 		}
 

--- a/lxd/device/gpu_physical.go
+++ b/lxd/device/gpu_physical.go
@@ -111,7 +111,7 @@ func (d *gpuPhysical) startContainer() (*deviceConfig.RunConfig, error) {
 	found := false
 
 	for _, gpu := range gpus.Cards {
-		// Skip any cards that are not selected
+		// Skip any cards that are not selected.
 		if !gpuSelected(d, gpu) {
 			continue
 		}
@@ -119,7 +119,7 @@ func (d *gpuPhysical) startContainer() (*deviceConfig.RunConfig, error) {
 		// We found a match.
 		found = true
 
-		// Setup DRM unix-char devices if present and matches id criteria (or if id not specified).
+		// Setup DRM unix-char devices if present.
 		if gpu.DRM.CardName != "" && gpu.DRM.CardDevice != "" && shared.PathExists(filepath.Join(gpuDRIDevPath, gpu.DRM.CardName)) {
 			path := filepath.Join(gpuDRIDevPath, gpu.DRM.CardName)
 			major, minor, err := d.deviceNumStringToUint32(gpu.DRM.CardDevice)
@@ -218,11 +218,8 @@ func (d *gpuPhysical) startVM() (*deviceConfig.RunConfig, error) {
 	var pciAddress string
 
 	for _, gpu := range gpus.Cards {
-		// Skip any cards that don't match the vendorid, pci, productid or DRM ID settings (if specified).
-		if (d.config["vendorid"] != "" && gpu.VendorID != d.config["vendorid"]) ||
-			(d.config["pci"] != "" && gpu.PCIAddress != d.config["pci"]) ||
-			(d.config["productid"] != "" && gpu.ProductID != d.config["productid"]) ||
-			(d.config["id"] != "" && (gpu.DRM == nil || fmt.Sprintf("%d", gpu.DRM.ID) != d.config["id"])) {
+		// Skip any cards that are not selected.
+		if !gpuSelected(d, gpu) {
 			continue
 		}
 

--- a/lxd/device/gpu_physical.go
+++ b/lxd/device/gpu_physical.go
@@ -120,44 +120,42 @@ func (d *gpuPhysical) startContainer() (*deviceConfig.RunConfig, error) {
 		found = true
 
 		// Setup DRM unix-char devices if present and matches id criteria (or if id not specified).
-		if gpu.DRM != nil && (d.config["id"] == "" || fmt.Sprintf("%d", gpu.DRM.ID) == d.config["id"]) {
-			if gpu.DRM.CardName != "" && gpu.DRM.CardDevice != "" && shared.PathExists(filepath.Join(gpuDRIDevPath, gpu.DRM.CardName)) {
-				path := filepath.Join(gpuDRIDevPath, gpu.DRM.CardName)
-				major, minor, err := d.deviceNumStringToUint32(gpu.DRM.CardDevice)
-				if err != nil {
-					return nil, err
-				}
-
-				err = unixDeviceSetupCharNum(d.state, d.inst.DevicesPath(), "unix", d.name, d.config, major, minor, path, false, &runConf)
-				if err != nil {
-					return nil, err
-				}
+		if gpu.DRM.CardName != "" && gpu.DRM.CardDevice != "" && shared.PathExists(filepath.Join(gpuDRIDevPath, gpu.DRM.CardName)) {
+			path := filepath.Join(gpuDRIDevPath, gpu.DRM.CardName)
+			major, minor, err := d.deviceNumStringToUint32(gpu.DRM.CardDevice)
+			if err != nil {
+				return nil, err
 			}
 
-			if gpu.DRM.RenderName != "" && gpu.DRM.RenderDevice != "" && shared.PathExists(filepath.Join(gpuDRIDevPath, gpu.DRM.RenderName)) {
-				path := filepath.Join(gpuDRIDevPath, gpu.DRM.RenderName)
-				major, minor, err := d.deviceNumStringToUint32(gpu.DRM.RenderDevice)
-				if err != nil {
-					return nil, err
-				}
+			err = unixDeviceSetupCharNum(d.state, d.inst.DevicesPath(), "unix", d.name, d.config, major, minor, path, false, &runConf)
+			if err != nil {
+				return nil, err
+			}
+		}
 
-				err = unixDeviceSetupCharNum(d.state, d.inst.DevicesPath(), "unix", d.name, d.config, major, minor, path, false, &runConf)
-				if err != nil {
-					return nil, err
-				}
+		if gpu.DRM.RenderName != "" && gpu.DRM.RenderDevice != "" && shared.PathExists(filepath.Join(gpuDRIDevPath, gpu.DRM.RenderName)) {
+			path := filepath.Join(gpuDRIDevPath, gpu.DRM.RenderName)
+			major, minor, err := d.deviceNumStringToUint32(gpu.DRM.RenderDevice)
+			if err != nil {
+				return nil, err
 			}
 
-			if gpu.DRM.ControlName != "" && gpu.DRM.ControlDevice != "" && shared.PathExists(filepath.Join(gpuDRIDevPath, gpu.DRM.ControlName)) {
-				path := filepath.Join(gpuDRIDevPath, gpu.DRM.ControlName)
-				major, minor, err := d.deviceNumStringToUint32(gpu.DRM.ControlDevice)
-				if err != nil {
-					return nil, err
-				}
+			err = unixDeviceSetupCharNum(d.state, d.inst.DevicesPath(), "unix", d.name, d.config, major, minor, path, false, &runConf)
+			if err != nil {
+				return nil, err
+			}
+		}
 
-				err = unixDeviceSetupCharNum(d.state, d.inst.DevicesPath(), "unix", d.name, d.config, major, minor, path, false, &runConf)
-				if err != nil {
-					return nil, err
-				}
+		if gpu.DRM.ControlName != "" && gpu.DRM.ControlDevice != "" && shared.PathExists(filepath.Join(gpuDRIDevPath, gpu.DRM.ControlName)) {
+			path := filepath.Join(gpuDRIDevPath, gpu.DRM.ControlName)
+			major, minor, err := d.deviceNumStringToUint32(gpu.DRM.ControlDevice)
+			if err != nil {
+				return nil, err
+			}
+
+			err = unixDeviceSetupCharNum(d.state, d.inst.DevicesPath(), "unix", d.name, d.config, major, minor, path, false, &runConf)
+			if err != nil {
+				return nil, err
 			}
 		}
 

--- a/lxd/device/gpu_physical.go
+++ b/lxd/device/gpu_physical.go
@@ -57,7 +57,7 @@ func (d *gpuPhysical) validateConfig(instConf instance.ConfigReader) error {
 	if d.config["pci"] != "" {
 		for _, field := range []string{"id", "productid", "vendorid"} {
 			if d.config[field] != "" {
-				return fmt.Errorf(`Cannot use %q when when "pci" is set`, field)
+				return fmt.Errorf(`Cannot use %q when "pci" is set`, field)
 			}
 		}
 
@@ -67,7 +67,7 @@ func (d *gpuPhysical) validateConfig(instConf instance.ConfigReader) error {
 	if d.config["id"] != "" {
 		for _, field := range []string{"pci", "productid", "vendorid"} {
 			if d.config[field] != "" {
-				return fmt.Errorf(`Cannot use %q when when "id" is set`, field)
+				return fmt.Errorf(`Cannot use %q when "id" is set`, field)
 			}
 		}
 	}

--- a/lxd/device/gpu_sriov.go
+++ b/lxd/device/gpu_sriov.go
@@ -44,7 +44,7 @@ func (d *gpuSRIOV) validateConfig(instConf instance.ConfigReader) error {
 	if d.config["pci"] != "" {
 		for _, field := range []string{"id", "productid", "vendorid"} {
 			if d.config[field] != "" {
-				return fmt.Errorf(`Cannot use %q when when "pci" is set`, field)
+				return fmt.Errorf(`Cannot use %q when "pci" is set`, field)
 			}
 		}
 
@@ -54,7 +54,7 @@ func (d *gpuSRIOV) validateConfig(instConf instance.ConfigReader) error {
 	if d.config["id"] != "" {
 		for _, field := range []string{"pci", "productid", "vendorid"} {
 			if d.config[field] != "" {
-				return fmt.Errorf(`Cannot use %q when when "id" is set`, field)
+				return fmt.Errorf(`Cannot use %q when "id" is set`, field)
 			}
 		}
 	}

--- a/lxd/device/gpu_sriov.go
+++ b/lxd/device/gpu_sriov.go
@@ -156,11 +156,8 @@ func (d *gpuSRIOV) getParentPCIAddresses() ([]string, error) {
 	var parentPCIAddresses []string
 
 	for _, gpu := range gpus.Cards {
-		// Skip any cards that don't match the vendorid, pci, productid or DRM ID settings (if specified).
-		if (d.config["vendorid"] != "" && gpu.VendorID != d.config["vendorid"]) ||
-			(d.config["pci"] != "" && gpu.PCIAddress != d.config["pci"]) ||
-			(d.config["productid"] != "" && gpu.ProductID != d.config["productid"]) ||
-			(d.config["id"] != "" && (gpu.DRM == nil || fmt.Sprintf("%d", gpu.DRM.ID) != d.config["id"])) {
+		// Skip any cards that are not selected.
+		if !gpuSelected(d.Config(), gpu) {
 			continue
 		}
 


### PR DESCRIPTION
Allow adding physical GPU devices to containers by setting the DRM ID with the `id` setting. Before a new device `/dev/nvidia[0123...]` was added for each graphics card regardless of what was configured with `id`. This was caused by a filtering mechanism that only took `vendorid`, `pci` and `productid` into account.

A new generic filter function is now used for each GPU device type (containers & virtual machines) which is checking all the attributes `vendorid`, `pci`, `productid` and `id`. 

For `gputype=mig` the check for the `id` filter is now also added since it was missing but supported according to the docs.

Fixes https://github.com/lxc/lxd/issues/11442