### PR TITLE
lxc/copy: Don't try and modify volatile.idmap.next on refresh if not set in source

### DIFF
--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -360,7 +360,9 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 		}
 
 		// Ensure we don't change the target's volatile.idmap.next value.
-		writable.Config["volatile.idmap.next"] = inst.Config["volatile.idmap.next"]
+		if inst.Config["volatile.idmap.next"] != writable.Config["volatile.idmap.next"] {
+			writable.Config["volatile.idmap.next"] = inst.Config["volatile.idmap.next"]
+		}
 
 		// Ensure we don't change the target's root disk pool.
 		srcRootDiskDeviceKey, _, _ := shared.GetRootDiskDevice(writable.Devices)


### PR DESCRIPTION

Fixes #11787