### PR TITLE
Network: Ping OVN virtual router external addresses when using physical uplink network

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1273,12 +1273,6 @@ func (d *Daemon) init() error {
 	maasMachine := d.localConfig.MAASMachine()
 
 	err = d.db.Cluster.Transaction(d.shutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
-		// Delete any left over operations for this member from the global database.
-		err := dbCluster.DeleteOperations(ctx, tx.Tx(), tx.GetNodeID())
-		if err != nil {
-			logger.Error("Failed cleaning up operations")
-		}
-
 		config, err := clusterConfig.Load(ctx, tx)
 		if err != nil {
 			return err

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1330,9 +1330,12 @@ func (n *ovn) pingOVNRouterIPv6() {
 		// By pinging the OVN router's external IP this will trigger an NDP request from the uplink bridge
 		// which will cause the OVN router to learn its MAC address.
 		go func() {
+			var err error
+
 			// Try several attempts as it can take a few seconds for the network to come up.
 			for i := 0; i < 5; i++ {
-				if pingIP(routerExtPortIPv6) {
+				err = pingIP(context.TODO(), routerExtPortIPv6)
+				if err == nil {
 					n.logger.Debug("OVN router external IPv6 address reachable", logger.Ctx{"ip": routerExtPortIPv6.String()})
 					return
 				}
@@ -1342,7 +1345,7 @@ func (n *ovn) pingOVNRouterIPv6() {
 
 			// We would expect this on a chassis node that isn't the active router gateway, it doesn't
 			// always indicate a problem.
-			n.logger.Debug("OVN router external IPv6 address unreachable", logger.Ctx{"ip": routerExtPortIPv6.String()})
+			n.logger.Debug("OVN router external IPv6 address unreachable", logger.Ctx{"ip": routerExtPortIPv6.String(), "err": err})
 		}()
 	}
 }

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1290,7 +1290,7 @@ func (n *ovn) startUplinkPortBridgeNative(uplinkNet Network, bridgeDevice string
 	}
 
 	// Attempt to learn uplink MAC.
-	n.pingOVNRouterIPv6()
+	n.pingOVNRouter()
 
 	revert.Success()
 	return nil
@@ -1310,17 +1310,27 @@ func (n *ovn) startUplinkPortBridgeOVS(uplinkNet Network, bridgeDevice string) e
 	}
 
 	// Attempt to learn uplink MAC.
-	n.pingOVNRouterIPv6()
+	n.pingOVNRouter()
 
 	revert.Success()
 	return nil
 }
 
-// pingOVNRouterIPv6 pings the OVN router's external IPv6 address to attempt to trigger MAC learning on uplink.
+// pingOVNRouter pings the OVN router's external IP addresses to attempt to trigger MAC learning on uplink.
 // This is to work around a bug in some versions of OVN.
-func (n *ovn) pingOVNRouterIPv6() {
-	routerExtPortIPv6 := net.ParseIP(n.config[ovnVolatileUplinkIPv6])
-	if routerExtPortIPv6 != nil {
+func (n *ovn) pingOVNRouter() {
+	var ips []net.IP
+
+	for _, key := range []string{ovnVolatileUplinkIPv4, ovnVolatileUplinkIPv6} {
+		ip := net.ParseIP(n.config[key])
+		if ip != nil {
+			ips = append(ips, ip)
+		}
+	}
+
+	for i := range ips {
+		ip := ips[i] // Local var
+
 		// Now that the OVN router is connected to the uplink bridge, attempt to ping the OVN
 		// router's external IPv6 from the LXD host running the uplink bridge in an attempt to trigger the
 		// OVN router to learn the uplink gateway's MAC address. This is to work around a bug in
@@ -1334,9 +1344,9 @@ func (n *ovn) pingOVNRouterIPv6() {
 
 			// Try several attempts as it can take a few seconds for the network to come up.
 			for i := 0; i < 5; i++ {
-				err = pingIP(context.TODO(), routerExtPortIPv6)
+				err = pingIP(context.TODO(), ip)
 				if err == nil {
-					n.logger.Debug("OVN router external IPv6 address reachable", logger.Ctx{"ip": routerExtPortIPv6.String()})
+					n.logger.Debug("OVN router external IP address reachable", logger.Ctx{"ip": ip.String()})
 					return
 				}
 
@@ -1345,7 +1355,7 @@ func (n *ovn) pingOVNRouterIPv6() {
 
 			// We would expect this on a chassis node that isn't the active router gateway, it doesn't
 			// always indicate a problem.
-			n.logger.Debug("OVN router external IPv6 address unreachable", logger.Ctx{"ip": routerExtPortIPv6.String(), "err": err})
+			n.logger.Debug("OVN router external IP address unreachable", logger.Ctx{"ip": ip.String(), "err": err})
 		}()
 	}
 }

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1432,6 +1432,9 @@ func (n *ovn) startUplinkPortPhysical(uplinkNet Network) error {
 		return fmt.Errorf("Failed to bring up uplink interface %q: %w", uplinkHostName, err)
 	}
 
+	// Attempt to learn uplink MAC.
+	n.pingOVNRouter()
+
 	revert.Success()
 	return nil
 }

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -682,15 +682,23 @@ func inRoutingTable(subnet *net.IPNet) bool {
 	return false
 }
 
-// pingIP sends a single ping packet to the specified IP, returns true if responds, false if not.
-func pingIP(ip net.IP) bool {
+// pingIP sends a single ping packet to the specified IP, returns nil error if IP is reachable.
+// If ctx doesn't have a deadline then the default timeout used is 1s.
+func pingIP(ctx context.Context, ip net.IP) error {
 	cmd := "ping"
 	if ip.To4() == nil {
 		cmd = "ping6"
 	}
 
-	_, err := shared.RunCommand(cmd, "-n", "-q", ip.String(), "-c", "1", "-W", "1")
-	return err == nil
+	timeout := time.Second * 1
+	deadline, ok := ctx.Deadline()
+	if ok {
+		timeout = time.Until(deadline)
+	}
+
+	_, err := shared.RunCommandContext(ctx, cmd, "-n", "-q", ip.String(), "-c", "1", "-w", fmt.Sprintf("%d", int(timeout.Seconds())))
+
+	return err
 }
 
 func pingSubnet(subnet *net.IPNet) bool {
@@ -701,7 +709,7 @@ func pingSubnet(subnet *net.IPNet) bool {
 	ping := func(ip net.IP) {
 		defer wgChecks.Done()
 
-		if !pingIP(ip) {
+		if pingIP(context.TODO(), ip) == nil {
 			return
 		}
 

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -709,7 +709,7 @@ func pingSubnet(subnet *net.IPNet) bool {
 	ping := func(ip net.IP) {
 		defer wgChecks.Done()
 
-		if pingIP(context.TODO(), ip) == nil {
+		if pingIP(context.TODO(), ip) != nil {
 			return
 		}
 

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -260,7 +260,10 @@ func (op *Operation) done() {
 		}
 
 		err := removeDBOperation(op)
-		if err != nil {
+		if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+			// Operations can be deleted from the database before the operation clean up go routine has
+			// run in cases where the project that the operation(s) are associated to is deleted first.
+			// So don't log warning if operation not found.
 			op.logger.Warn("Failed to delete operation", logger.Ctx{"status": op.status, "err": err})
 		}
 	}()

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -546,7 +546,7 @@ func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blo
 
 		err = json.Unmarshal([]byte(imgJSON), &imgInfo)
 		if err != nil {
-			return -1, err
+			return -1, fmt.Errorf("Failed unmarshalling image info %q: %w (%q)", imgPath, err, imgJSON)
 		}
 
 		// Belt and braces qcow2 check.


### PR DESCRIPTION
Fixes #11492

This works around a bug in OVN where in some cases the ARP/NDP neighbour learning of the uplink next-hop address is not triggered for egress traffic from instances.

LXD will try and ping the OVN network's external router IPs from each member, and if they can reach the OVN virtual router then this is sufficient to trigger next-hop neighbour learning inside OVN.

This is not a full solution to the problem, as if the LXD members cannot reach the OVN virtual router (which is a valid configuration) then pings from LXD members will not be able to trigger neighbour learning inside OVN.
