### PR TITLE
lxd/instance_logs: Cleanup function call

### DIFF
--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -574,9 +574,7 @@ func instanceExecOutputGet(d *Daemon, r *http.Request) response.Response {
 	ent := response.FileResponseEntry{
 		Path:     filepath.Join(inst.ExecOutputPath(), file),
 		Filename: file,
-		Cleanup: func() {
-			cleanup.Fail()
-		},
+		Cleanup:  cleanup.Fail,
 	}
 
 	s.Events.SendLifecycle(projectName, lifecycle.InstanceLogRetrieved.Event(file, inst, request.CreateRequestor(r), nil))

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -445,11 +445,6 @@ func (r *fileResponse) Render(w http.ResponseWriter) error {
 
 	for _, entry := range r.files {
 		var rd io.Reader
-
-		if entry.Cleanup != nil {
-			defer entry.Cleanup()
-		}
-
 		if entry.File != nil {
 			rd = entry.File
 		} else {
@@ -471,6 +466,10 @@ func (r *fileResponse) Render(w http.ResponseWriter) error {
 		_, err = io.Copy(fw, rd)
 		if err != nil {
 			return err
+		}
+
+		if entry.Cleanup != nil {
+			entry.Cleanup()
 		}
 	}
 


### PR DESCRIPTION
This PR references the remaining comments in #11791:
- [x] `lxd/instance_logs/instanceExecOutputGet` - Call cleanup.Fail function directly
- [x] `lxd/response/fileResponse.Render` - Avoid calling cleanup function in defer for responses with multiple files