### PR TITLE
lxd/instance/drivers: Also use virtio-gpu-pci on Intel

### DIFF
--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -350,17 +350,9 @@ type qemuGpuOpts struct {
 }
 
 func qemuGPU(opts *qemuGpuOpts) []cfgSection {
-	var pciName string
-
-	if opts.architecture == osarch.ARCH_64BIT_INTEL_X86 {
-		pciName = "virtio-vga"
-	} else {
-		pciName = "virtio-gpu-pci"
-	}
-
 	entriesOpts := qemuDevEntriesOpts{
 		dev:     opts.dev,
-		pciName: pciName,
+		pciName: "virtio-gpu-pci",
 		ccwName: "virtio-gpu-ccw",
 	}
 


### PR DESCRIPTION
I couldn't find any obvious regressions from this change.
It aligns things with other platforms and also fixes handling by seabios when trying to enable CSM.