### PR TITLE
Bug vsock loading init

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7878,14 +7878,11 @@ func (d *qemu) checkFeatures(hostArch int, qemuPath string) (map[string]any, err
 		features["vhost_net"] = struct{}{}
 	}
 
-	vsockID, err := vsock.ContextID()
-	if err != nil || vsockID > 2147483647 {
-		// Fallback to the default ID for a host system if we're getting
-		// an error or are getting a clearly invalid value.
-		vsockID = 2
+	// Check if vhos-vsock is available
+	err = util.LoadModule("vhost_vsock")
+	if err != nil {
+		features["vhost_vsock"] = struct{}{}
 	}
-
-	features["vsockID"] = vsockID
 
 	return features, nil
 }

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7318,7 +7318,14 @@ func (d *qemu) vsockID() int {
 	// We then add the VM's own instance id (1 or higher) to give us a
 	// unique, non-clashing context ID for our guest.
 
-	return int(d.state.OS.VsockID) + 1 + d.id
+	vsockID, err := vsock.ContextID()
+	if err != nil || vsockID > 2147483647 {
+		// Fallback to the default ID for a host system if we're getting
+		// an error or are getting a clearly invalid value.
+		vsockID = 2
+	}
+
+	return int(vsockID) + 1 + d.id
 }
 
 // InitPID returns the instance's current process ID.

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mdlayher/vsock"
-
 	"github.com/lxc/lxd/lxd/cgroup"
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/storage/filesystem"
@@ -94,9 +92,6 @@ type OS struct {
 
 	// LXC features
 	LXCFeatures map[string]bool
-
-	// VM features
-	VsockID uint32
 
 	// OS info
 	ReleaseInfo   map[string]string

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -181,18 +181,6 @@ func (s *OS) Init() ([]cluster.Warning, error) {
 	cgroup.Init()
 	s.CGInfo = cgroup.GetInfo()
 
-	// Fill in the VsockID.
-	_ = util.LoadModule("vhost_vsock")
-
-	vsockID, err := vsock.ContextID()
-	if err != nil || vsockID > 2147483647 {
-		// Fallback to the default ID for a host system if we're getting
-		// an error or are getting a clearly invalid value.
-		vsockID = 2
-	}
-
-	s.VsockID = vsockID
-
 	// Fill in the OS release info.
 	osInfo, err := osarch.GetLSBRelease()
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/lxc/lxd/issues/11794

## Description:
This pull request addresses the following issues:

- Fixes the loading of the vsock module in the OS struct's init function.
- Modifies the retrieval of the vsock context ID.
- Updates the vsock module loading to occur in the checkFeatures function of qemu.
- Implements a new function, vsockID(), in qemu to retrieve the context ID.

## Changes Made:

- Modified the OS struct's init function to remove the loading of the vsock module.
- Added a new function, checkFeatures(), in qemu to load the vsock module and check if it is available.
- Implemented the vsockID() function in qemu to retrieve the vsock context ID.
- Updated the necessary function calls and references in the codebase to accommodate the changes.