### PR TITLE
Introduce auth_user_name and auth_user_method in /1.0

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2230,3 +2230,11 @@ When the offline cluster member is evacuated, only remote-backed instances will 
 
 ## `instances_state_total`
 This extension adds a new `total` field to `InstanceStateDisk` and `InstanceStateMemory`, both part of the instance's state API.
+
+## `auth_user`
+Add current user details to the main API endpoint.
+
+This introduces:
+
+* `auth_user_name`
+* `auth_user_method`

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5101,6 +5101,18 @@ definitions:
                 readOnly: true
                 type: array
                 x-go-name: AuthMethods
+            auth_user_method:
+                description: The current user login method as seen by LXD
+                example: unix
+                readOnly: true
+                type: string
+                x-go-name: AuthUserMethod
+            auth_user_name:
+                description: The current user username as seen by LXD
+                example: uid=201105
+                readOnly: true
+                type: string
+                x-go-name: AuthUserName
             config:
                 additionalProperties: {}
                 description: Server configuration map (refer to doc/server.md)

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -369,6 +369,9 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 
 	fullSrv := api.Server{ServerUntrusted: srv}
 	fullSrv.Environment = env
+	requestor := request.CreateRequestor(r)
+	fullSrv.AuthUserName = requestor.Username
+	fullSrv.AuthUserMethod = requestor.Protocol
 
 	if rbac.UserIsAdmin(r) {
 		fullSrv.Config, err = daemonConfigRender(s)

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -195,6 +195,20 @@ type Server struct {
 	ServerPut       `yaml:",inline"`
 	ServerUntrusted `yaml:",inline"`
 
+	// The current user username as seen by LXD
+	// Read only: true
+	// Example: uid=201105
+	//
+	// API extension: auth_user
+	AuthUserName string `json:"auth_user_name" yaml:"auth_user_name"`
+
+	// The current user login method as seen by LXD
+	// Read only: true
+	// Example: unix
+	//
+	// API extension: auth_user
+	AuthUserMethod string `json:"auth_user_method" yaml:"auth_user_method"`
+
 	// Read-only status/configuration information
 	// Read only: true
 	Environment ServerEnvironment `json:"environment" yaml:"environment"`

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -372,6 +372,7 @@ var APIExtensions = []string{
 	"ovn_nic_acceleration_vdpa",
 	"cluster_healing",
 	"instances_state_total",
+	"auth_user",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This is primarily meant as a way to confirm that the user is authenticating using the method that they think they are.
It's not really needed by LXD usually but it's something that will be useful for the UI as that way it can know whether to offer an option to logout in the case of OIDC.