### PR TITLE
lxd/storage/zfs: Fix ZFS does not respect atime=off option

### DIFF
--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -252,6 +252,29 @@ func (d *zfs) getDatasetProperty(dataset string, key string) (string, error) {
 	return strings.TrimSpace(output), nil
 }
 
+func (d *zfs) getDatasetProperties(dataset string, keys ...string) (map[string]string, error) {
+	output, err := shared.RunCommand("zfs", "get", "-H", "-p", "-o", "property,value", strings.Join(keys, ","), dataset)
+	if err != nil {
+		return nil, err
+	}
+
+	props := make(map[string]string, len(keys))
+
+	for _, row := range strings.Split(output, "\n") {
+		prop := strings.Split(row, "\t")
+
+		if len(prop) < 2 {
+			continue
+		}
+
+		key := prop[0]
+		val := prop[1]
+		props[key] = val
+	}
+
+	return props, nil
+}
+
 // version returns the ZFS version based on package or kernel module version.
 func (d *zfs) version() (string, error) {
 	// This function is only really ever relevant on Ubuntu as the only

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -2012,8 +2012,20 @@ func (d *zfs) MountVolume(vol Volume, op *operations.Operation) error {
 				return err
 			}
 
+			var volOptions []string
+
+			props, _ := d.getDatasetProperties(dataset, "atime", "relatime")
+
+			if props["atime"] == "off" {
+				volOptions = append(volOptions, "noatime")
+			} else if props["relatime"] == "off" {
+				volOptions = append(volOptions, "strictatime")
+			}
+
+			mountFlags, mountOptions := filesystem.ResolveMountOptions(volOptions)
+
 			// Mount the dataset.
-			err = TryMount(dataset, mountPath, "zfs", 0, "")
+			err = TryMount(dataset, mountPath, "zfs", mountFlags, mountOptions)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Read ZFS dataset `atime` property and convert it to appropriate mount flag to ensure `noatime` mount option is set accordingly.

Fixes #11659