### PR TITLE
api: Allow the selection of cluster groups when moving instances

### DIFF
--- a/doc/howto/cluster_manage_instance.md
+++ b/doc/howto/cluster_manage_instance.md
@@ -37,3 +37,8 @@ For example, to move the instance `c1` to the cluster member `server1`, use the 
     lxc start c1
 
 See {ref}`move-instances` for more information.
+
+To move an instance to a member of a cluster group, use the group name prefixed with `@` for the `--target` flag.
+For example:
+
+    lxc move c1 --target @group1

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -87,108 +87,88 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Invalid instance name"))
 	}
 
-	targetNode := queryParam(r, "target")
-
 	// Flag indicating whether the node running the container is offline.
 	sourceNodeOffline := false
 
-	// Flag indicating whether the node the container should be moved to is
-	// online (only relevant if "?target=<node>" was given).
-	targetNodeOffline := false
-
-	// A POST to /containers/<name>?target=<node> is meant to be used to
-	// move a container from one node to another within a cluster.
-	if targetNode != "" {
-		// Determine if either the source node (the one currently
-		// running the container) or the target node are offline.
-		//
-		// If the target node is offline, we return an error.
-		//
-		// If the source node is offline and the container is backed by
-		// ceph, we'll just assume that the container is not running
-		// and it's safe to move it.
-		//
-		// TODO: add some sort of "force" flag to the API, to signal
-		//       that the user really wants to move the container even
-		//       if we can't know for sure that it's indeed not
-		//       running?
-		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			p, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
-			if err != nil {
-				return fmt.Errorf("Failed loading project: %w", err)
-			}
-
-			apiProject, err := p.ToAPI(ctx, tx.Tx())
-			if err != nil {
-				return err
-			}
-
-			// Check if user is allowed to use cluster member targeting
-			err = project.CheckClusterTargetRestriction(r, apiProject, targetNode)
-			if err != nil {
-				return err
-			}
-
-			// Load target node.
-			node, err := tx.GetNodeByName(ctx, targetNode)
-			if err != nil {
-				return fmt.Errorf("Failed to get target node: %w", err)
-			}
-
-			targetNodeOffline = node.IsOffline(s.GlobalConfig.OfflineThreshold())
-
-			// Load source node.
-			address, err := tx.GetNodeAddressOfInstance(ctx, projectName, name, instanceType)
-			if err != nil {
-				return fmt.Errorf("Failed to get address of instance's member: %w", err)
-			}
-
-			if address == "" {
-				// Local node.
-				sourceNodeOffline = false
-				return nil
-			}
-
-			node, err = tx.GetNodeByAddress(ctx, address)
-			if err != nil {
-				return fmt.Errorf("Failed to get source member for %s: %w", address, err)
-			}
-
-			sourceNodeOffline = node.IsOffline(s.GlobalConfig.OfflineThreshold())
-
-			return nil
-		})
-		if err != nil {
-			return response.SmartError(err)
-		}
+	// Check if clustered.
+	clustered, err := cluster.Enabled(s.DB.Node)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("Failed checking cluster state: %w", err))
 	}
 
-	if targetNode != "" && targetNodeOffline {
-		return response.BadRequest(fmt.Errorf("Target node is offline"))
+	var targetProject *api.Project
+	var targetMemberInfo *db.NodeInfo
+	var candidateMembers []db.NodeInfo
+
+	target := queryParam(r, "target")
+	if !clustered && target != "" {
+		return response.BadRequest(fmt.Errorf("Target only allowed when clustered"))
+	}
+
+	// A POST to /instances/<name>?target=<member> is meant to be used to
+	// move an instance from one member to another within a cluster.
+	//
+	// Determine if either the source node (the one currently
+	// running the instance) or the target node are offline.
+	//
+	// If the target node is offline, we return an error.
+	//
+	// If the source node is offline and the instance is backed by
+	// ceph, we'll just assume that the instance is not running
+	// and it's safe to move it.
+	//
+	// TODO: add some sort of "force" flag to the API, to signal
+	//       that the user really wants to move the instance even
+	//       if we can't know for sure that it's indeed not
+	//       running?
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Load source node.
+		sourceAddress, err := tx.GetNodeAddressOfInstance(ctx, projectName, name, instanceType)
+		if err != nil {
+			return fmt.Errorf("Failed to get address of instance's member: %w", err)
+		}
+
+		if sourceAddress == "" {
+			// Local node.
+			sourceNodeOffline = false
+			return nil
+		}
+
+		sourceMemberInfo, err := tx.GetNodeByAddress(ctx, sourceAddress)
+		if err != nil {
+			return fmt.Errorf("Failed to get source member for %q: %w", sourceAddress, err)
+		}
+
+		sourceNodeOffline = sourceMemberInfo.IsOffline(s.GlobalConfig.OfflineThreshold())
+
+		return nil
+	})
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	// Check whether to forward the request to the node that is running the
-	// container. Here are the possible cases:
+	// instance. Here are the possible cases:
 	//
-	// 1. No "?target=<node>" parameter was passed. In this case this is
-	//    just a container rename, with no move, and we want the request to be
-	//    handled by the node which is actually running the container.
+	// 1. No "?target=<member>" parameter was passed. In this case this is
+	//    just an instance rename, with no move, and we want the request to be
+	//    handled by the node which is actually running the instance.
 	//
-	// 2. The "?target=<node>" parameter was set and the node running the
-	//    container is online. In this case we want to forward the request to
+	// 2. The "?target=<member>" parameter was set and the node running the
+	//    instance is online. In this case we want to forward the request to
 	//    that node, which might do things like unmapping the RBD volume for
-	//    ceph containers.
+	//    ceph instances.
 	//
-	// 3. The "?target=<node>" parameter was set but the node running the
-	//    container is offline. We don't want to forward to the request to
-	//    that node and we don't want to load the container here (since
-	//    it's not a local container): we'll be able to handle the request
-	//    at all only if the container is backed by ceph. We'll check for
+	// 3. The "?target=<member>" parameter was set but the node running the
+	//    instance is offline. We don't want to forward to the request to
+	//    that node and we don't want to load the instance here (since
+	//    it's not a local instance): we'll be able to handle the request
+	//    at all only if the instance is backed by ceph. We'll check for
 	//    that just below.
 	//
 	// Cases 1. and 2. are the ones for which the conditional will be true
-	// and we'll either forward the request or load the container.
-	if targetNode == "" || !sourceNodeOffline {
+	// and we'll either forward the request or load the instance.
+	if target == "" || !sourceNodeOffline {
 		// Handle requests targeted to a container on a different node.
 		resp, err := forwardedResponseIfInstanceIsRemote(s, r, projectName, name, instanceType)
 		if err != nil {
@@ -203,6 +183,67 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		resp := forwardedResponseIfTargetIsRemote(s, r)
 		if resp != nil {
 			return resp
+		}
+	}
+
+	inst, err := instance.LoadByProjectAndName(s, projectName, name)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// Run the cluster placement after potentially forwarding the request to another member.
+	if target != "" && clustered {
+		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			p, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
+			if err != nil {
+				return err
+			}
+
+			targetProject, err = p.ToAPI(ctx, tx.Tx())
+			if err != nil {
+				return err
+			}
+
+			allMembers, err := tx.GetNodes(ctx)
+			if err != nil {
+				return fmt.Errorf("Failed getting cluster members: %w", err)
+			}
+
+			var targetGroupName string
+
+			targetMemberInfo, targetGroupName, err = project.CheckTarget(ctx, r, tx, targetProject, target, allMembers)
+			if err != nil {
+				return err
+			}
+
+			if targetMemberInfo == nil {
+				clusterGroupsAllowed := project.GetRestrictedClusterGroups(targetProject)
+
+				candidateMembers, err = tx.GetCandidateMembers(ctx, allMembers, []int{inst.Architecture()}, targetGroupName, clusterGroupsAllowed, s.GlobalConfig.OfflineThreshold())
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		// If no member was selected yet, pick the member with the least number of instances.
+		if targetMemberInfo == nil {
+			err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+				targetMemberInfo, err = tx.GetNodeWithLeastInstances(ctx, candidateMembers)
+				return err
+			})
+			if err != nil {
+				return response.SmartError(err)
+			}
+		}
+
+		if targetMemberInfo.IsOffline(s.GlobalConfig.OfflineThreshold()) {
+			return response.BadRequest(fmt.Errorf("Target cluster member is offline"))
 		}
 	}
 
@@ -230,11 +271,6 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 	_, err = reqRaw.GetBool("live")
 	if err != nil {
 		req.Live = true
-	}
-
-	inst, err := instance.LoadByProjectAndName(s, projectName, name)
-	if err != nil {
-		return response.SmartError(err)
 	}
 
 	// If new instance name not supplied, assume it will be keeping its current name.
@@ -288,7 +324,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			return operations.OperationResponse(op)
 		}
 
-		if targetNode != "" {
+		if targetMemberInfo != nil {
 			// Check if instance has backups.
 			backups, err := s.DB.Cluster.GetInstanceBackups(projectName, name)
 			if err != nil {
@@ -301,7 +337,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			run := func(op *operations.Operation) error {
-				return migrateInstance(s, r, inst, targetNode, req, op)
+				return migrateInstance(s, r, inst, targetMemberInfo.Name, req, op)
 			}
 
 			resources := map[string][]api.URL{}

--- a/test/main.sh
+++ b/test/main.sh
@@ -230,6 +230,7 @@ if [ "${1:-"all"}" != "standalone" ]; then
     run_test test_clustering_image_refresh "clustering image refresh"
     run_test test_clustering_evacuation "clustering evacuation"
     run_test test_clustering_instance_placement_scriptlet "clustering instance placement scriptlet"
+    run_test test_clustering_move "clustering move"
     run_test test_clustering_edit_configuration "clustering config edit"
     run_test test_clustering_remove_members "clustering config remove members"
     run_test test_clustering_autotarget "clustering autotarget member"

--- a/test/suites/clustering_move.sh
+++ b/test/suites/clustering_move.sh
@@ -1,0 +1,199 @@
+test_clustering_move() {
+  # shellcheck disable=2039,3043,SC2034
+  local LXD_DIR
+
+  setup_clustering_bridge
+  prefix="lxd$$"
+  bridge="${prefix}"
+
+  setup_clustering_netns 1
+  LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD_ONE_DIR}"
+  ns1="${prefix}1"
+  spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
+
+  # Add a newline at the end of each line. YAML as weird rules..
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
+
+  # Spawn a second node
+  setup_clustering_netns 2
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD_TWO_DIR}"
+  ns2="${prefix}2"
+  spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}"
+
+  # Spawn a third node
+  setup_clustering_netns 3
+  LXD_THREE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD_THREE_DIR}"
+  ns3="${prefix}3"
+  spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}"
+
+  ensure_import_testimage
+
+  # Preparation
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster group create foobar1
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster group assign node1 foobar1,default
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster group create foobar2
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster group assign node2 foobar2,default
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster group create foobar3
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster group assign node3 foobar3,default
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc init testimage c1 --target node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc init testimage c2 --target node2
+  LXD_DIR="${LXD_ONE_DIR}" lxc init testimage c3 --target node3
+
+  # Perform default move tests falling back to the built in logic of choosing the node
+  # with the least number of instances when targeting a cluster group.
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target node2
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target @foobar1
+  LXD_DIR="${LXD_ONE_DIR}" lxc info c1 | grep -q "Location: node1"
+
+  # c1 can be moved within the same cluster group if it has multiple members
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target=@default
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target=@default
+
+  # c1 cannot be moved within the same cluster group if it has a single member
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target=@foobar3
+  LXD_DIR="${LXD_ONE_DIR}" lxc info c1 | grep -q "Location: node3"
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target=@foobar3 || false
+
+  # Perform standard move tests using the `scheduler.instance` cluster member setting.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster set node2 scheduler.instance=group
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster set node3 scheduler.instance=manual
+
+  # At this stage we have:
+  # - node1 in group foobar1,default accepting all instances
+  # - node2 in group foobar2,default accepting group-only targeting
+  # - node3 in group foobar3,default accepting manual targeting only
+  # - c1 is deployed on node1
+  # - c2 is deployed on node2
+  # - c3 is deployed on node3
+
+  # c1 can be moved to node2 by group targeting.
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target=@foobar2
+  LXD_DIR="${LXD_ONE_DIR}" lxc info c1 | grep -q "Location: node2"
+
+  # c2 can be moved to node1 by manual targeting.
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c2 --target=node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc info c2 | grep -q "Location: node1"
+
+  # c1 cannot be moved to node3 by group targeting.
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target=@foobar3 || false
+
+  # c2 can be moved to node2 by manual targeting.
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c2 --target=node2
+
+  # c3 can be moved to node1 by manual targeting.
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c3 --target=node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc info c3 | grep -q "Location: node1"
+
+  # c3 can be moved back to node by by manual targeting.
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c3 --target=node3
+  LXD_DIR="${LXD_ONE_DIR}" lxc info c3 | grep -q "Location: node3"
+
+  # Clean up
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster unset node2 scheduler.instance
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster unset node3 scheduler.instance
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target node1
+
+  # Perform extended scheduler tests involving the `instance.placement.scriptlet` global setting.
+  # Start by statically targeting node3 (index 0).
+  cat << EOF | LXD_DIR="${LXD_ONE_DIR}" lxc config set instances.placement.scriptlet=-
+def instance_placement(request, candidate_members):
+        if request.reason != "relocation":
+                return "Expecting reason relocation"
+
+        # Set statically target to 1st member.
+        set_target(candidate_members[0].server_name)
+
+        return
+EOF
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target @foobar3
+  LXD_DIR="${LXD_ONE_DIR}" lxc info c1 | grep -q "Location: node3"
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c2 --target @foobar3
+  LXD_DIR="${LXD_ONE_DIR}" lxc info c2 | grep -q "Location: node3"
+
+  # Ensure that setting an invalid target won't interrupt the move and fall back to the built in behavior.
+  # Equally distribute the instances beforehand so that node1 will get selected.
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c2 --target node2
+
+  cat << EOF | LXD_DIR="${LXD_ONE_DIR}" lxc config set instances.placement.scriptlet=-
+def instance_placement(request, candidate_members):
+        # Set invalid member target.
+        result = set_target("foo")
+        log_warn("Setting invalid member target result: ", result)
+
+        return
+EOF
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target @foobar1
+  LXD_DIR="${LXD_ONE_DIR}" lxc info c1 | grep -q "Location: node1"
+
+  # If the scriptlet produces a runtime error, the move fails.
+  cat << EOF | LXD_DIR="${LXD_ONE_DIR}" lxc config set instances.placement.scriptlet=-
+def instance_placement(request, candidate_members):
+        # Try to access an invalid index (non existing member)
+        log_info("Accessing invalid field ", candidate_members[42])
+
+        return
+EOF
+
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target @foobar2 || false
+
+  # If the scriptlet intentionally runs into an error, the move fails.
+  cat << EOF | LXD_DIR="${LXD_ONE_DIR}" lxc config set instances.placement.scriptlet=-
+def instance_placement(request, candidate_members):
+        log_error("instance placement not allowed") # Log placement error.
+
+        fail("Instance not allowed") # Fail to prevent instance creation.
+EOF
+
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target @foobar2 || false
+
+  # Cleanup
+  LXD_DIR="${LXD_ONE_DIR}" lxc config unset instances.placement.scriptlet
+
+  # Perform project restriction tests.
+  # At this stage we have:
+  # - node1 in group foobar1,default
+  # - node2 in group foobar2,default
+  # - node3 in group foobar3,default
+  # - c1 is deployed on node1
+  # - c2 is deployed on node2
+  # - c3 is deployed on node3
+  # - default project restricted to cluster groups foobar1,foobar2
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set default restricted=true
+  LXD_DIR="${LXD_ONE_DIR}" lxc project set default restricted.cluster.groups=foobar1,foobar2
+
+  # Moving to a node that is not a member of foobar1 or foobar2 will fail.
+  # The same applies for an unlisted group
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target @foobar3 || false
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc move c2 --target node3 || false
+
+  # Moving instances in between the restricted groups
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target node2
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c2 --target @foobar1
+  LXD_DIR="${LXD_ONE_DIR}" lxc move c3 --target node1
+
+  # Cleanup
+  LXD_DIR="${LXD_ONE_DIR}" lxc delete -f c1 c2 c3
+
+  LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+  sleep 0.5
+  rm -f "${LXD_THREE_DIR}/unix.socket"
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_ONE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+  kill_lxd "${LXD_THREE_DIR}"
+}


### PR DESCRIPTION
When launching new instances, the target node or cluster group can be defined by setting the `--target` flag. If specified the cluster members `scheduler.instance` or global `instances.placement.scriptlet` config setting gets evaluated to find a fitting target node. 

The same should apply when moving instances between cluster members. Especially when specifying `--target @group`, the scheduler mechanism can now pick up the right node from the list of cluster group members.

Since lots of the permission checking is done for both instance creation and movement, both endpoints should use the same functions for checking permissions when the `target` query parameter is set. The logic is now moved into the `lxd/project` package.

A new test suite is added for testing the movement of instances in clusters.

Fixes #11666