### PR TITLE
lxd/recover: Use configuration defaults

### DIFF
--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -177,6 +177,12 @@ func internalRecoverScan(s *state.State, userPools []api.StoragePoolsPost, valid
 					return response.SmartError(fmt.Errorf("Failed to initialise unknown pool %q: %w", p.Name, err))
 				}
 
+				// Populate configuration with default values.
+				err := pool.Driver().FillConfig()
+				if err != nil {
+					return response.SmartError(fmt.Errorf("Failed to evaluate the default configuration values for unknown pool %q: %w", p.Name, err))
+				}
+
 				err = pool.Driver().Validate(poolInfo.Config)
 				if err != nil {
 					return response.SmartError(fmt.Errorf("Failed config validation for unknown pool %q: %w", p.Name, err))

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -87,9 +87,27 @@ func (d *cephfs) Info() Info {
 	}
 }
 
+// FillConfig populates the storage pool's configuration file with the default values.
+func (d *cephfs) FillConfig() error {
+	if d.config["cephfs.cluster_name"] == "" {
+		d.config["cephfs.cluster_name"] = CephDefaultCluster
+	}
+
+	if d.config["cephfs.user.name"] == "" {
+		d.config["cephfs.user.name"] = CephDefaultUser
+	}
+
+	return nil
+}
+
 // Create is called during pool creation and is effectively using an empty driver struct.
 // WARNING: The Create() function cannot rely on any of the struct attributes being set.
 func (d *cephfs) Create() error {
+	err := d.FillConfig()
+	if err != nil {
+		return err
+	}
+
 	// Config validation.
 	if d.config["source"] == "" {
 		return fmt.Errorf("Missing required source name/path")
@@ -97,15 +115,6 @@ func (d *cephfs) Create() error {
 
 	if d.config["cephfs.path"] != "" && d.config["cephfs.path"] != d.config["source"] {
 		return fmt.Errorf("cephfs.path must match the source")
-	}
-
-	// Set default properties if missing.
-	if d.config["cephfs.cluster_name"] == "" {
-		d.config["cephfs.cluster_name"] = CephDefaultCluster
-	}
-
-	if d.config["cephfs.user.name"] == "" {
-		d.config["cephfs.user.name"] = CephDefaultUser
 	}
 
 	d.config["cephfs.path"] = d.config["source"]

--- a/lxd/storage/drivers/driver_cephobject.go
+++ b/lxd/storage/drivers/driver_cephobject.go
@@ -105,10 +105,8 @@ func (d *cephobject) Validate(config map[string]string) error {
 	return d.validatePool(config, rules, nil)
 }
 
-// Create is called during pool creation and is effectively using an empty driver struct.
-// WARNING: The Create() function cannot rely on any of the struct attributes being set.
-func (d *cephobject) Create() error {
-	// Set default properties if missing.
+// FillConfig populates the storage pool's configuration file with the default values.
+func (d *cephobject) FillConfig() error {
 	if d.config["cephobject.cluster_name"] == "" {
 		d.config["cephobject.cluster_name"] = CephDefaultCluster
 	}
@@ -119,6 +117,17 @@ func (d *cephobject) Create() error {
 
 	if d.config["cephobject.radosgw.endpoint"] == "" {
 		return fmt.Errorf(`"cephobject.radosgw.endpoint" option is required`)
+	}
+
+	return nil
+}
+
+// Create is called during pool creation and is effectively using an empty driver struct.
+// WARNING: The Create() function cannot rely on any of the struct attributes being set.
+func (d *cephobject) Create() error {
+	err := d.FillConfig()
+	if err != nil {
+		return err
 	}
 
 	// Check if there is an existing cephobjectRadosgwAdminUser user.

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -46,12 +46,22 @@ func (d *dir) Info() Info {
 	}
 }
 
-// Create is called during pool creation and is effectively using an empty driver struct.
-// WARNING: The Create() function cannot rely on any of the struct attributes being set.
-func (d *dir) Create() error {
+// FillConfig populates the storage pool's configuration file with the default values.
+func (d *dir) FillConfig() error {
 	// Set default source if missing.
 	if d.config["source"] == "" {
 		d.config["source"] = GetPoolMountPath(d.name)
+	}
+
+	return nil
+}
+
+// Create is called during pool creation and is effectively using an empty driver struct.
+// WARNING: The Create() function cannot rely on any of the struct attributes being set.
+func (d *dir) Create() error {
+	err := d.FillConfig()
+	if err != nil {
+		return err
 	}
 
 	sourcePath := shared.HostPath(d.config["source"])

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -97,6 +97,16 @@ func (d *lvm) Info() Info {
 	}
 }
 
+// FillConfig populates the storage pool's configuration file with the default values.
+func (d *lvm) FillConfig() error {
+	// Set default thin pool name if not specified.
+	if d.usesThinpool() && d.config["lvm.thinpool_name"] == "" {
+		d.config["lvm.thinpool_name"] = lvmThinpoolDefaultName
+	}
+
+	return nil
+}
+
 // Create creates the storage pool on the storage device.
 func (d *lvm) Create() error {
 	d.config["volatile.initial_source"] = d.config["source"]
@@ -110,9 +120,9 @@ func (d *lvm) Create() error {
 	revert := revert.New()
 	defer revert.Fail()
 
-	// Set default thin pool name if not specified.
-	if d.usesThinpool() && d.config["lvm.thinpool_name"] == "" {
-		d.config["lvm.thinpool_name"] = lvmThinpoolDefaultName
+	err = d.FillConfig()
+	if err != nil {
+		return err
 	}
 
 	var usingLoopFile bool

--- a/lxd/storage/drivers/driver_mock.go
+++ b/lxd/storage/drivers/driver_mock.go
@@ -36,6 +36,10 @@ func (d *mock) Info() Info {
 	}
 }
 
+func (d *mock) FillConfig() error {
+	return nil
+}
+
 func (d *mock) Create() error {
 	return nil
 }

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -37,6 +37,7 @@ type Driver interface {
 	Logger() logger.Logger
 
 	// Pool.
+	FillConfig() error
 	Create() error
 	Delete(op *operations.Operation) error
 	// Mount mounts a storage pool if needed, returns true if we caused a new mount, false if already mounted.


### PR DESCRIPTION
Extract the defaults generation inside each pool driver's `Create()` function into a separate `PopulateConfig()` function.

On `lxd recover`, the pool's configuration is populated with default values before the configuration gets validated.

Fixes #10862