### PR TITLE
Instances: Fix file descriptor leaks of liblxc

### DIFF
--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -115,18 +115,18 @@ func ensureImageIsLocallyAvailable(s *state.State, r *http.Request, img *api.Ima
 }
 
 // instanceCreateFromImage creates an instance from a rootfs image.
-func instanceCreateFromImage(s *state.State, r *http.Request, img *api.Image, args db.InstanceArgs, op *operations.Operation) (instance.Instance, error) {
+func instanceCreateFromImage(s *state.State, r *http.Request, img *api.Image, args db.InstanceArgs, op *operations.Operation) error {
 	revert := revert.New()
 	defer revert.Fail()
 
 	// Validate the type of the image matches the type of the instance.
 	imgType, err := instancetype.New(img.Type)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if imgType != args.Type {
-		return nil, fmt.Errorf("Requested image's type %q doesn't match instance type %q", imgType, args.Type)
+		return fmt.Errorf("Requested image's type %q doesn't match instance type %q", imgType, args.Type)
 	}
 
 	// Set the "image.*" keys.
@@ -142,7 +142,7 @@ func instanceCreateFromImage(s *state.State, r *http.Request, img *api.Image, ar
 	// Create the instance.
 	inst, instOp, cleanup, err := instance.CreateInternal(s, args, true)
 	if err != nil {
-		return nil, fmt.Errorf("Failed creating instance record: %w", err)
+		return fmt.Errorf("Failed creating instance record: %w", err)
 	}
 
 	revert.Add(cleanup)
@@ -157,28 +157,28 @@ func instanceCreateFromImage(s *state.State, r *http.Request, img *api.Image, ar
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	pool, err := storagePools.LoadByInstance(s, inst)
 	if err != nil {
-		return nil, fmt.Errorf("Failed loading instance storage pool: %w", err)
+		return fmt.Errorf("Failed loading instance storage pool: %w", err)
 	}
 
 	err = pool.CreateInstanceFromImage(inst, img.Fingerprint, op)
 	if err != nil {
-		return nil, fmt.Errorf("Failed creating instance from image: %w", err)
+		return fmt.Errorf("Failed creating instance from image: %w", err)
 	}
 
 	revert.Add(func() { _ = inst.Delete(true) })
 
 	err = inst.UpdateBackupFile()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	revert.Success()
-	return inst, nil
+	return nil
 }
 
 // instanceCreateAsCopyOpts options for copying an instance.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -8091,8 +8091,6 @@ func (d *lxc) cgroup(cc *liblxc.Container) (*cgroup.CGroup, error) {
 	if cc != nil {
 		rw.cc = cc
 		rw.conf = true
-	} else {
-		rw.cc = d.c
 	}
 
 	if rw.cc == nil {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -8460,7 +8460,7 @@ func (d *lxc) getFSStats() (*metrics.MetricSet, error) {
 	return out, nil
 }
 
-func (d *lxc) loadRawLXCConfig() error {
+func (d *lxc) loadRawLXCConfig(cc *liblxc.Container) error {
 	// Load the LXC raw config.
 	lxcConfig, ok := d.expandedConfig["raw.lxc"]
 	if !ok {
@@ -8484,7 +8484,7 @@ func (d *lxc) loadRawLXCConfig() error {
 	}
 
 	// Load the config.
-	err = d.c.LoadConfigFile(f.Name())
+	err = cc.LoadConfigFile(f.Name())
 	if err != nil {
 		return fmt.Errorf("Failed to load config file %q: %w", f.Name(), err)
 	}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -117,8 +117,7 @@ func createFromImage(s *state.State, r *http.Request, p api.Project, profiles []
 			return err
 		}
 
-		_, err = instanceCreateFromImage(s, r, img, args, op)
-		return err
+		return instanceCreateFromImage(s, r, img, args, op)
 	}
 
 	resources := map[string][]string{}

--- a/test/suites/fdleak.sh
+++ b/test/suites/fdleak.sh
@@ -27,6 +27,9 @@ test_fdleak() {
     exit 0
   )
 
+  # Check for open handles to liblxc lxc.log files.
+  ! find "/proc/${pid}/fd" -ls | grep lxc.log || false
+
   for i in $(seq 20); do
     afterfds=$(/bin/ls "/proc/${pid}/fd" | wc -l)
     leakedfds=$((afterfds - beforefds))


### PR DESCRIPTION
Sets finalizer for garbage collector to release liblxc.Container reference inside `d.initLXC` rather than on `d` initialisation.
This way the finalizer is always certain to have been activated if `d.c` has been set, and also there's no need to activate it if `d.c` isn't being set.

This still results in some FDs lingering until the garbage collector runs normally or is triggered by `/internal/gc` request.
But it does fix the long-lasting FD leaks for liblxc log files.

It also updates the fdleak test to check for them as it was previously missing these.

Finally, as a step on the road to performing more proactive releasing of the liblxc.Container reference I have made `d.initLXC` return the `liblxc.Container` reference and updated the call sites to use the returned variable rather than using `d.c` directly.

This way we can control concurrent access of `d.c` and it helps to reveal the usage patterns of the liblxc.Container reference so that potentially `d.initLXC()` stops caching the result in `d.c` in the future.

Fixes #11780