### PR TITLE
lxd/device: Fix regression for not properly checking for GPU DRM information

### DIFF
--- a/lxd/device/gpu.go
+++ b/lxd/device/gpu.go
@@ -71,8 +71,21 @@ func gpuValidationRules(requiredFields []string, optionalFields []string) map[st
 // Check if the device matches the given GPU card.
 // It matches based on vendorid, pci, productid or id setting of the device.
 func gpuSelected(device config.Device, gpu api.ResourcesGPUCard) bool {
-	return !((device["vendorid"] != "" && gpu.VendorID != device["vendorid"]) ||
-		(device["pci"] != "" && gpu.PCIAddress != device["pci"]) ||
-		(device["productid"] != "" && gpu.ProductID != device["productid"]) ||
-		(device["id"] != "" && (gpu.DRM == nil || fmt.Sprintf("%d", gpu.DRM.ID) != device["id"])))
+	if device["vendorid"] != "" && gpu.VendorID == device["vendorid"] {
+		return true
+	}
+
+	if device["pci"] != "" && gpu.PCIAddress == device["pci"] {
+		return true
+	}
+
+	if device["productid"] != "" && gpu.ProductID == device["productid"] {
+		return true
+	}
+
+	if device["id"] != "" && gpu.DRM != nil && fmt.Sprintf("%d", gpu.DRM.ID) == device["id"] {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
Finding from https://github.com/lxc/lxd/pull/11825, fixes a bug introduced with https://github.com/lxc/lxd/pull/11799