### PR TITLE
github: re-add `gettext` package for static-analysis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
 
           sudo apt-get install --no-install-recommends -y \
             curl \
+            gettext \
             git \
             libacl1-dev \
             libcap-dev \

--- a/Makefile
+++ b/Makefile
@@ -242,8 +242,7 @@ po/%.po: po/$(DOMAIN).pot
 update-po:
 	set -eu; \
 	for lang in $(LINGUAS); do\
-	    msgmerge -U $$lang.po po/$(DOMAIN).pot; \
-	    rm -f $$lang.po~; \
+	    msgmerge --backup=none -U $$lang.po po/$(DOMAIN).pot; \
 	done
 
 .PHONY: update-pot

--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,7 @@ po/%.po: po/$(DOMAIN).pot
 
 .PHONY: update-po
 update-po:
+	set -eu; \
 	for lang in $(LINGUAS); do\
 	    msgmerge -U $$lang.po po/$(DOMAIN).pot; \
 	    rm -f $$lang.po~; \

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ lxd-migrate:
 
 .PHONY: lxd-doc
 lxd-doc:
-	@go version > /dev/null 2>&1 || (echo "go is not installed for lxd-doc installation." && exit 1)
+	@go version > /dev/null 2>&1 || { echo "go is not installed for lxd-doc installation."; exit 1; }
 	cd lxd/config/generate && CGO_ENABLED=0 go build -o $(GOPATH)/bin/lxd-doc
 	@echo "LXD-DOC built successfully"
 


### PR DESCRIPTION
Follow-up on the nice #11833 PR. The PR drop some unused package but also `gettext` which went unnoticed because our `Makefile` was unintentionally ignoring errors due to how `for` loops are processed by the shell.

The "Run static analysis" section of https://github.com/lxc/lxd/actions/runs/5277182345/jobs/9544871231 contains some:
```
/bin/sh: 2: msgmerge: not found
```
Which is how this was noticed.