### PR TITLE
test: Add support for running test suite on Github runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,90 @@ jobs:
         run: |
           make static-analysis
 
+  system-tests:
+    env:
+      CGO_LDFLAGS_ALLOW: "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
+      LXD_SHIFTFS_DISABLE: "true"
+    name: System tests
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ["cluster", "standalone"]
+        backend: ["dir", "btrfs", "lvm", "zfs"]
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.x
+
+      - name: Install dependencies
+        run: |
+          sudo add-apt-repository ppa:ubuntu-lxc/lxc-git-master -y --no-update
+          sudo add-apt-repository ppa:dqlite/dev -y --no-update
+          sudo apt-get update
+
+          sudo apt-get autoremove docker uidmap --purge -y
+          sudo ip link delete docker0
+          sudo nft flush ruleset
+
+          sudo apt-get install --no-install-recommends -y \
+            curl \
+            dnsutils \
+            git \
+            libacl1-dev \
+            libcap-dev \
+            libdbus-1-dev \
+            libdqlite-dev \
+            liblxc-dev \
+            libseccomp-dev \
+            libselinux-dev \
+            libsqlite3-dev \
+            libtool \
+            libudev-dev \
+            make \
+            pkg-config\
+            acl \
+            attr \
+            bind9-dnsutils \
+            btrfs-progs \
+            busybox-static \
+            dnsmasq-base \
+            gettext \
+            jq \
+            lvm2 \
+            nftables \
+            quota \
+            rsync \
+            socat \
+            sqlite3 \
+            squashfs-tools \
+            tar \
+            tcl \
+            thin-provisioning-tools \
+            uuid-runtime \
+            xfsprogs \
+            xz-utils \
+            zfsutils-linux
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download go dependencies
+        run: |
+          go mod download
+
+      - name: Run LXD build
+        run: |
+          make
+
+      - name: "Run system tests (${{ matrix.suite }}, ${{ matrix.backend }})"
+        run: |
+          chmod +x ~
+          echo "root:1000000:1000000000" | sudo tee /etc/subuid /etc/subgid
+          cd test
+          sudo --preserve-env=PATH,GOPATH,GORACE,LXD_INSPECT,LXD_DEBUG,LXD_VERBOSE,LXD_BACKEND,LXD_NIC_BRIDGED_DRIVER,LXD_CEPH_CLUSTER,LXD_CEPH_CEPHOBJECT_RADOSGW,LXD_OFFLINE,LXD_CONCURRENT,LXD_SKIP_TESTS,LXD_REQUIRED_TESTS,LXD_SHIFTFS_DISABLE LXD_OFFLINE=1 LXD_TMPFS=1 LXD_VERBOSE=1 LXD_BACKEND=${{ matrix.backend }} ./main.sh ${{ matrix.suite }}
+
   client:
     name: Unit tests (client)
     strategy:
@@ -146,6 +230,7 @@ jobs:
   linkcheck:
     name: Check links (documentation)
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/lxd/instance_rebuild.go
+++ b/lxd/instance_rebuild.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/version"
 )
 
 // swagger:operation POST /1.0/instances/{instance_name}/rebuild instances instance_post
@@ -137,8 +138,8 @@ func instanceRebuildPost(d *Daemon, r *http.Request) response.Response {
 		return instanceRebuildFromImage(s, r, inst, sourceImage, op)
 	}
 
-	resources := map[string][]string{}
-	resources["instances"] = []string{name}
+	resources := map[string][]api.URL{}
+	resources["instances"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", name)}
 
 	if inst.Type() == instancetype.Container {
 		resources["containers"] = resources["instances"]

--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -187,9 +187,10 @@ func (d *btrfs) deleteSubvolume(rootPath string, recursion bool) error {
 		return err
 	}
 
+	// Try and ensure volume is writable to possibility of destroy failing.
 	err := d.setSubvolumeReadonlyProperty(rootPath, false)
 	if err != nil {
-		return fmt.Errorf("Failed setting subvolume writable %q: %w", rootPath, err)
+		d.logger.Warn("Failed setting subvolume writable", logger.Ctx{"path": rootPath, "err": err})
 	}
 
 	// Attempt to delete the root subvol itself (short path).
@@ -212,7 +213,7 @@ func (d *btrfs) deleteSubvolume(rootPath string, recursion bool) error {
 			subSubVolPath := filepath.Join(rootPath, subSubVol)
 			err = d.setSubvolumeReadonlyProperty(subSubVolPath, false)
 			if err != nil {
-				return fmt.Errorf("Failed setting subvolume writable %q: %w", subSubVolPath, err)
+				d.logger.Warn("Failed setting subvolume writable", logger.Ctx{"path": subSubVolPath, "err": err})
 			}
 		}
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3637,6 +3637,7 @@ test_clustering_events() {
 
   # Check events were distributed.
   for i in 1 2 3; do
+    cat "${TEST_DIR}/node${i}.log"
     grep -Fc "instance-restarted" "${TEST_DIR}/node${i}.log" | grep -Fx 6
   done
 
@@ -3669,6 +3670,7 @@ test_clustering_events() {
   grep -Fc "instance-restarted" "${TEST_DIR}/node1.log"
   grep -Fc "instance-restarted" "${TEST_DIR}/node1.log" | grep -Fx 7
   for i in 2 3; do
+    cat "${TEST_DIR}/node${i}.log"
     grep -Fc "instance-restarted" "${TEST_DIR}/node${i}.log" | grep -Fx 6
   done
 


### PR DESCRIPTION
Looks like there is an intermittent issue with btrfs when the disk is purposefully filled up to cause dqlite errors:

```
lxc storage delete lxdtest-M5g --force-local
time="2023-06-15T15:37:26Z" level=warning msg="Failed setting subvolume writable" driver=btrfs err="Failed to run: btrfs property set -f -ts /home/runner/work/lxd/lxd/test/tmp.08S/M5g/storage-pools/lxdtest-M5g ro false: exit status 1 (ERROR: Could not get subvolume flags: Inappropriate ioctl for device)" path=/home/runner/work/lxd/lxd/test/tmp.08S/M5g/storage-pools/lxdtest-M5g pool=lxdtest-M5g
Error: Failed deleting subvolume "/home/runner/work/lxd/lxd/test/tmp.08S/M5g/storage-pools/lxdtest-M5g": Failed to run: btrfs subvolume delete /home/runner/work/lxd/lxd/test/tmp.08S/M5g/storage-pools/lxdtest-M5g: exit status 1 (ERROR: Not a Btrfs filesystem: Invalid argument)
```

But this is intermittent and I'll investigate separately.