### PR TITLE
test: skip cleanup if executing from a GitHub Action runner

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -83,11 +83,15 @@ cleanup() {
     read -r _
   fi
 
-  echo "==> Cleaning up"
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "==> Skipping cleanup (GitHub Action runner detected)"
+  else
+    echo "==> Cleaning up"
 
-  umount -l "${TEST_DIR}/dev"
-  kill_external_auth_daemon "$TEST_DIR"
-  cleanup_lxds "$TEST_DIR"
+    umount -l "${TEST_DIR}/dev"
+    kill_external_auth_daemon "$TEST_DIR"
+    cleanup_lxds "$TEST_DIR"
+  fi
 
   echo ""
   echo ""


### PR DESCRIPTION
According to previous CI runs, that's save between 2-60s which isn't a lot but still better than nothing.

We do the same with LXD Cloud.