### PR TITLE
lxd/bgp: Allow one hour for LXD restart

### DIFF
--- a/lxd/bgp/server.go
+++ b/lxd/bgp/server.go
@@ -428,7 +428,7 @@ func (s *Server) addPeer(address net.IP, asn uint32, password string, holdTime u
 		// Allow for 120s offline before route removal.
 		GracefulRestart: &bgpAPI.GracefulRestart{
 			Enabled:     true,
-			RestartTime: 120,
+			RestartTime: 3600,
 		},
 
 		// Always allow for the maximum multihop.


### PR DESCRIPTION
This should allow for larger clusters to refresh without losing advertisements.