### PR TITLE
lxd/ip: improve performance of `getVhostVDPADevInPath`

### DIFF
--- a/lxd/ip/vdpa.go
+++ b/lxd/ip/vdpa.go
@@ -112,12 +112,12 @@ func getVhostVDPADevInPath(parentPath string) (*VhostVDPA, error) {
 
 	defer fd.Close()
 
-	fileInfos, err := fd.Readdir(-1)
+	entries, err := fd.ReadDir(-1)
 	if err != nil {
-		return nil, fmt.Errorf("Can not get FileInfos: %v", err)
+		return nil, fmt.Errorf("Can not get DirEntries: %v", err)
 	}
 
-	for _, file := range fileInfos {
+	for _, file := range entries {
 		if strings.Contains(file.Name(), "vhost-vdpa") && file.IsDir() {
 			devicePath := filepath.Join(vdpaVhostDevDir, file.Name())
 			info, err := os.Stat(devicePath)


### PR DESCRIPTION
As recommended in the official doc [^1], `(*os.File).ReadDir` is a more efficient choice if we only need to know the name and whether it is a directory.

Sample benchmark:

```go
func Benchmark_Readdir(b *testing.B) {
	for i := 0; i < b.N; i++ {
		f, err := os.Open("/dev")
		if err != nil {
			b.Fatal(err)
		}

		_, err = f.Readdir(-1)
		if err != nil {
			f.Close()
			b.Fatal(err)
		}
		f.Close()
	}
}

func Benchmark_ReadDir(b *testing.B) {
	for i := 0; i < b.N; i++ {
		f, err := os.Open("/dev")
		if err != nil {
			b.Fatal(err)
		}

		_, err = f.ReadDir(-1)
		if err != nil {
			f.Close()
			b.Fatal(err)
		}
		f.Close()
	}
}
```

```
goos: linux
goarch: amd64
pkg: example
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
Benchmark_Readdir-16    	    6583	    400522 ns/op	   54612 B/op	     592 allocs/op
Benchmark_ReadDir-16    	   14204	     77281 ns/op	   21890 B/op	     399 allocs/op
PASS
ok  	example	4.614s
```

[^1]: "Most clients are better served by the more efficient ReadDir method." https://pkg.go.dev/os#File.Readdir