### PR TITLE
VM: Load vhost_vsock kernel module if /dev/kvm is available

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7774,14 +7774,14 @@ func (d *qemu) Info() instance.Info {
 		return data
 	}
 
-	if !shared.PathExists("/dev/vsock") {
-		data.Error = fmt.Errorf("Vsock support is missing (no /dev/vsock)")
-		return data
-	}
-
 	err := util.LoadModule("vhost_vsock")
 	if err != nil {
 		data.Error = fmt.Errorf("vhost_vsock kernel module not loaded")
+		return data
+	}
+
+	if !shared.PathExists("/dev/vsock") {
+		data.Error = fmt.Errorf("Vsock support is missing (no /dev/vsock)")
 		return data
 	}
 


### PR DESCRIPTION
Otherwise /dev/vsock may not be present and VM support detection will fail.

Fixes regression from https://github.com/lxc/lxd/pull/11834

Related to https://github.com/lxc/lxd/issues/11794