### PR TITLE
github: Extended testing

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18.x
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -39,13 +39,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Install Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.18.x
-
-      - name: Checkout code
-        uses: actions/checkout@v3
 
       - name: Create build directory
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,7 @@ jobs:
           sudo --preserve-env=PATH,GOPATH,GORACE,LXD_INSPECT,LXD_DEBUG,LXD_VERBOSE,LXD_BACKEND,LXD_NIC_BRIDGED_DRIVER,LXD_CEPH_CLUSTER,LXD_CEPH_CEPHOBJECT_RADOSGW,LXD_OFFLINE,LXD_CONCURRENT,LXD_SKIP_TESTS,LXD_REQUIRED_TESTS,LXD_SHIFTFS_DISABLE LXD_OFFLINE=1 LXD_TMPFS=1 LXD_VERBOSE=1 LXD_BACKEND=${{ matrix.backend }} ./main.sh ${{ matrix.suite }}
 
   client:
-    name: Unit tests (client)
+    name: Client tests
     strategy:
       fail-fast: false
       matrix:
@@ -186,17 +186,17 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - name: Test client package
+      - name: Unit tests (client)
         env:
           CGO_ENABLED: 0
         run: go test -v ./client/...
 
-      - name: Test lxc package
+      - name: Unit tests (lxc)
         env:
           CGO_ENABLED: 0
         run: go test -v ./lxc/...
 
-      - name: Test shared package
+      - name: Unit tests (shared)
         env:
           CGO_ENABLED: 0
         run: go test -v ./shared/...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,9 @@ jobs:
     name: Static analysis
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Install Go
         uses: actions/setup-go@v4
         with:
@@ -51,9 +54,6 @@ jobs:
           chmod +x shellcheck-v0.8.0/shellcheck
           sudo mv shellcheck-v0.8.0/shellcheck /bin/shellcheck
 
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - name: Download go dependencies
         run: |
           go mod download
@@ -78,6 +78,9 @@ jobs:
         suite: ["cluster", "standalone"]
         backend: ["dir", "btrfs", "lvm", "zfs"]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Install Go
         uses: actions/setup-go@v4
         with:
@@ -132,9 +135,6 @@ jobs:
             xz-utils \
             zfsutils-linux
 
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - name: Download go dependencies
         run: |
           go mod download
@@ -164,13 +164,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Install Go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
-
-      - name: Checkout code
-        uses: actions/checkout@v3
 
       - name: Test client package
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18.x
 
@@ -79,7 +79,7 @@ jobs:
         backend: ["dir", "btrfs", "lvm", "zfs"]
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18.x
 
@@ -165,7 +165,7 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  static-analysis:
-    name: Static analysis
+  code-tests:
+    name: Code tests
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -38,6 +38,7 @@ jobs:
             libdbus-1-dev \
             libdqlite-dev \
             liblxc-dev \
+            lxc-templates \
             libseccomp-dev \
             libselinux-dev \
             libsqlite3-dev \
@@ -65,6 +66,10 @@ jobs:
       - name: Run static analysis
         run: |
           make static-analysis
+
+      - name: Unit tests (all)
+        run: |
+          sudo go test ./...
 
   system-tests:
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,8 +75,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        go: ["1.18.x"]
         suite: ["cluster", "standalone"]
         backend: ["dir", "btrfs", "lvm", "zfs"]
+        include:
+          - go: stable
+            suite: cluster
+            backend: dir
+          - go: stable
+            suite: standalone
+            backend: dir
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -84,7 +93,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: ${{ matrix.go }}
 
       - name: Install dependencies
         run: |
@@ -143,7 +152,7 @@ jobs:
         run: |
           make
 
-      - name: "Run system tests (${{ matrix.suite }}, ${{ matrix.backend }})"
+      - name: "Run system tests (${{ matrix.go }}, ${{ matrix.suite }}, ${{ matrix.backend }})"
         run: |
           chmod +x ~
           echo "root:1000000:1000000000" | sudo tee /etc/subuid /etc/subgid

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3563,11 +3563,11 @@ test_clustering_events() {
   LXD_DIR="${LXD_ONE_DIR}" lxc info c1 | grep -q "Location: node1"
   LXD_DIR="${LXD_ONE_DIR}" lxc launch testimage c2 --target=node2
 
-  LXD_DIR="${LXD_ONE_DIR}" lxc monitor --type=lifecycle > "${TEST_DIR}/node1.log" &
+  LXD_DIR="${LXD_ONE_DIR}" stdbuf -oL lxc monitor --type=lifecycle > "${TEST_DIR}/node1.log" &
   monitorNode1PID=$!
-  LXD_DIR="${LXD_TWO_DIR}" lxc monitor --type=lifecycle > "${TEST_DIR}/node2.log" &
+  LXD_DIR="${LXD_TWO_DIR}" stdbuf -oL lxc monitor --type=lifecycle > "${TEST_DIR}/node2.log" &
   monitorNode2PID=$!
-  LXD_DIR="${LXD_THREE_DIR}" lxc monitor --type=lifecycle > "${TEST_DIR}/node3.log" &
+  LXD_DIR="${LXD_THREE_DIR}" stdbuf -oL lxc monitor --type=lifecycle > "${TEST_DIR}/node3.log" &
   monitorNode3PID=$!
 
   # Restart instance generating restart lifecycle event.

--- a/test/suites/database.sh
+++ b/test/suites/database.sh
@@ -87,6 +87,7 @@ test_database_no_disk_space(){
     lxc delete -f c
   )
 
-  umount -l "${GLOBAL_DB_DIR}"
+  shutdown_lxd "${LXD_NOSPACE_DIR}"
+  umount "${GLOBAL_DB_DIR}"
   kill_lxd "${LXD_NOSPACE_DIR}"
 }


### PR DESCRIPTION
- Adds latest Go version test for `dir` driver.
- Adds unit testing as part of "Code tests" (formerly Static analysis) workflow.
- Renames "Unit tests (client)" to "Client tests".
- Adds support for opportunistic Go dependency build caching (seems to work only for later Go versions).
- Attempts fix of intermittent BTRFS test failure.