### PR TITLE
github: Combine documentation steps into single job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -251,58 +251,33 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v3
 
-  woke:
-    name: Inclusive naming (documentation)
+  documentation:
+    name: Documentation tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: woke
-        uses: get-woke/woke-action@v0
-        with:
-          # Cause the check to fail on any broke rules
-          fail-on-error: true
-          woke-args: "doc/*.md doc/**/*.md -c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml"
-
-  spellcheck:
-    name: Spellcheck (documentation)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Aspell
+      - name: Install dependencies
         run: |
           sudo apt-get install aspell aspell-en
+          sudo snap install mdl
 
-      - name: Build docs and run spellchecker
+      - name: Run markdown linter
+        run: |
+          make doc-lint
+
+      - name: Run spell checker
         run: |
           make doc-spellcheck
 
-  linkcheck:
-    name: Check links (documentation)
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Run inclusive naming checker
+        uses: get-woke/woke-action@v0
+        with:
+          woke-args: "doc/*.md doc/**/*.md -c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml"
 
-      - name: Run linkchecker
+      - name: Run link checker
+        # This can fail intermittently due to external resources being unavailable.
+        continue-on-error: true
         run: |
           make doc-linkcheck
-
-  markdownlint:
-    name: Markdownlint (documentation)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install mdl
-        run: |
-          sudo snap install mdl
-
-      - name: Run mdl
-        run: |
-          make doc-lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,6 +120,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          set -x
           sudo add-apt-repository ppa:ubuntu-lxc/lxc-git-master -y --no-update
           sudo add-apt-repository ppa:dqlite/dev -y --no-update
           sudo apt-get update
@@ -179,17 +180,30 @@ jobs:
       - name: Setup MicroCeph
         if: ${{ matrix.backend == 'ceph' }}
         run: |
+          set -x
           sudo apt-get install --no-install-recommends -y snapd ceph-common
           sudo snap install microceph --edge
           sleep 5
           sudo microceph cluster bootstrap
           sudo microceph.ceph config set global osd_pool_default_size 1
           sudo microceph.ceph config set global mon_allow_pool_delete true
+          sudo microceph.ceph config set global osd_memory_target 939524096
           sudo microceph.ceph osd crush rule rm replicated_rule
           sudo microceph.ceph osd crush rule create-replicated replicated default osd
+          for flag in nosnaptrim noscrub nobackfill norebalance norecover noscrub nodeep-scrub; do
+              sudo microceph.ceph osd set $flag
+          done
+          # Use ephemeral disk mounted on /mnt for ceph OSD.
+          # The block-devices plug doesn't allow accessing /dev/loopX devices so we make those same devices
+          # available under alternate names (/dev/sdiY) that are not used inside GitHub Action runners.
           sudo swapoff /mnt/swapfile
-          sudo umount /mnt
-          sudo microceph disk add --wipe /dev/sdb
+          sudo rm -f /mnt/swapfile
+          loop_file="/mnt/ceph-osd.img"
+          sudo fallocate -l 10G "${loop_file}"
+          loop_dev="$(sudo losetup --show --direct-io=on --nooverlap -f "${loop_file}")"
+          devInfo=($(sudo stat -c '%t %T' "${loop_dev}"))
+          sudo mknod -m 0660 /dev/sdia b 0x"${devInfo[0]}" 0x"${devInfo[1]}"
+          sudo microceph disk add --wipe /dev/sdia
           sudo rm -rf /etc/ceph
           sudo ln -s /var/snap/microceph/current/conf/ /etc/ceph
           sleep 10

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,7 +125,7 @@ jobs:
           sudo apt-get update
 
           sudo snap remove lxd --purge
-          sudo apt-get autoremove moby-containerd docker uidmap --purge -y
+          sudo apt-get autopurge moby-containerd docker uidmap -y
           sudo ip link delete docker0
           sudo nft flush ruleset
 


### PR DESCRIPTION
This avoids needing to build the docs multiple times and keeps the documentation steps together.

Also fixes intermittent disk corruption in ceph tests due to the ephemeral disk being on a different device on different runners.
In the end I went for a loop file on the ephemeral disk's filesystem as this will be the most generic solution for different future environments.

Also introduces some ceph optimisations suggested by @stgraber 