### PR TITLE
Disable direct IO for QEMU drives on tmpfs storage

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3530,7 +3530,8 @@ func (d *qemu) addDriveConfig(bootIndexes map[string]int, driveConf deviceConfig
 
 			// If backing FS is ZFS or BTRFS, avoid using direct I/O and use host page cache only.
 			// We've seen ZFS lock up and BTRFS checksum issues when using direct I/O on image files.
-			if fsType == "zfs" || fsType == "btrfs" {
+			// tmpfs doesn't support direct I/O
+			if fsType == "zfs" || fsType == "btrfs" || fsType == "tmpfs" {
 				if driveConf.FSType != "iso9660" {
 					// Only warn about using writeback cache if the drive image is writable.
 					d.logger.Warn("Using writeback cache I/O", logger.Ctx{"device": driveConf.DevName, "devPath": srcDevPath, "fsType": fsType})


### PR DESCRIPTION
This pull request addresses an issue where LXD is currently configured to use Direct IO for virtual machine disk when the disk has been allocated from a dir-type storage on tmpfs. As tmpfs doesn't support Direct IO, this configuration causes the initiation of a virtual machine to fail, with the following error message:

```
Failed setting up device via monitor: Failed adding block device for disk device "root": Failed adding block device: Could not dup FD for /dev/fdset/0 flags 4002: Invalid argument
```

This pull request proposes to disable the Direct IO option for QEMU drives whenever LXD identifies that the disk has been allocated within a tmpfs storage. Tests confirmed that LXD can launch a virtual machine on tmpfs with this patch.

```bash
mkdir /mnt/tmpfs/
mount -t tmpfs -o size=20G lxd-storage /mnt/tmpfs/
lxc storage create tmpfs dir source=/mnt/tmpfs/
lxc launch ubuntu:22.04 test-tmpfs --vm -s tmpfs
```