### PR TITLE
doc: move installation instructions from the website

### DIFF
--- a/doc/.sphinx/.wordlist.txt
+++ b/doc/.sphinx/.wordlist.txt
@@ -37,6 +37,7 @@ checksums
 Chocolatey
 CIDR
 CLI
+COPR
 CPUs
 CRIU
 CRL
@@ -155,6 +156,7 @@ OIDC
 OpenID
 OpenMetrics
 OpenSSL
+OpenSUSE
 OSD
 overcommit
 overcommitting
@@ -208,6 +210,7 @@ SIGTERM
 simplestreams
 SLAAC
 SMTP
+Snapcraft
 Solaris
 SPAs
 SPL

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -5,16 +5,149 @@ relatedlinks: "[LXD&#32;-&#32;Installation](https://linuxcontainers.org/lxd/gett
 
 # How to install LXD
 
-The easiest way to install LXD is to install one of the available packages, but you can also install LXD from the sources.
+The easiest way to install LXD is to {ref}`install one of the available packages <installing-from-package>`, but you can also {ref}`install LXD from the sources <installing_from_source>`.
 
-% Include some content from [../README.md](../README.md)
-```{include} ../README.md
-    :start-after: <!-- Include start installing -->
-    :end-before: <!-- Include end installing -->
+After installing LXD, make sure you have a `lxd` group on your system.
+Users in this group can interact with LXD.
+See {ref}`installing-manage-access` for instructions.
+
+## Choose your release
+
+LXD maintains different release branches in parallel:
+
+- Long term support (LTS) releases: currently LXD 5.0.x and LXD 4.0.x
+- Feature releases: LXD 5.x
+
+LTS releases are recommended for production environments, because they benefit from regular bugfix and security updates.
+However, there are no new features added to an LTS release, nor any kind of behavioral change.
+
+To get all the latest features and monthly updates to LXD, use the feature release branch instead.
+
+(installing-from-package)=
+## Install LXD from a package
+
+The LXD daemon only works on Linux.
+The client tool (`lxc`) is available on most platforms.
+
+### Linux
+
+The easiest way to install LXD on Linux is to install the {ref}`installing-snap-package`, which is available for different Linux distributions.
+
+If this option does not work for you, see the {ref}`installing-other`.
+
+(installing-snap-package)=
+#### Snap package
+
+LXD publishes and tests [snap packages](https://snapcraft.io/lxd) that work for a number of Linux distributions (for example, Ubuntu, Arch Linux, Debian, Fedora, and OpenSUSE).
+
+Complete the following steps to install the snap:
+
+1. Check the [provided distributions](https://jenkins.linuxcontainers.org/job/lxd-test-snap-latest-stable/) to see if a snap is available for your Linux distribution.
+   If it is not, use one of the {ref}`installing-other`.
+
+1. Install `snapd`.
+   See the [installation instructions](https://snapcraft.io/docs/core/install) in the Snapcraft documentation.
+
+1. Install the snap package.
+   For the latest feature release, use:
+
+        sudo snap install lxd
+
+   For the LXD 5.0 LTS release, use:
+
+        sudo snap install lxd --channel=5.0/stable
+
+For more information about LXD snap packages (regarding more versions, update management etc.), see [Managing the LXD snap](https://discuss.linuxcontainers.org/t/managing-the-lxd-snap/8178).
+
+```{note}
+On Ubuntu 18.04, if you previously had the LXD deb package installed, you can migrate all your existing data over with the following command:
+
+        sudo lxd.migrate
 ```
+
+(installing-other)=
+#### Other installation options
+
+Some Linux distributions provide installation options other than the snap package.
+
+````{tabs}
+
+```{group-tab} Alpine Linux
+
+To install the feature branch of LXD on Alpine Linux, run:
+
+    apk add lxd
+```
+
+```{group-tab} Arch Linux
+
+To install the feature branch of LXD on Arch Linux, run:
+
+    pacman -S lxd
+```
+
+```{group-tab} Fedora
+
+Fedora RPM packages for LXC/LXD are available in the [COPR repository](https://copr.fedorainfracloud.org/coprs/ganto/lxc4/).
+
+To install the LXD package for the feature branch, run:
+
+    dnf copr enable ganto/lxc4
+    dnf install lxd
+
+See the [Installation Guide](https://github.com/ganto/copr-lxc4/wiki) for more detailed installation instructions.
+```
+
+```{group-tab} Gentoo
+
+To install the feature branch of LXD on Gentoo, run:
+
+    emerge --ask lxd
+```
+
+````
+
+### Other operating systems
+
+```{important}
+The builds for other operating systems include only the client, not the server.
+```
+
+````{tabs}
+
+```{group-tab} macOS
+
+LXD publishes builds of the LXD client for macOS through [Homebrew](https://brew.sh/).
+
+To install the feature branch of LXD, run:
+
+    brew install lxc
+```
+
+```{group-tab} Windows
+
+The LXD client on Windows is provided as a [Chocolatey](https://community.chocolatey.org/packages/lxc) package.
+To install it:
+
+1. Install Chocolatey by following the [installation instructions](https://docs.chocolatey.org/en-us/choco/setup).
+1. Install the LXD client:
+
+        choco install lxc
+```
+
+````
+
+You can also find native builds of the LXD client on [GitHub](https://github.com/lxc/lxd/actions).
+To download a specific build:
+
+1. Make sure that you are logged into your GitHub account.
+1. Filter for the branch or tag that you are interested in (for example, the latest release tag or `master`). <!-- wokeignore:rule=master -->
+1. Select the latest build and download the suitable artifact.
 
 (installing_from_source)=
 ## Install LXD from source
+
+Follow these instructions if you want to build and install LXD from the source code.
 
 We recommend having the latest versions of `liblxc` (>= 4.0.0 required)
 available for LXD development. Additionally, LXD requires Golang 1.18 or
@@ -123,6 +256,27 @@ sudo -E PATH=${PATH} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} $(go env GOPATH)/bin/lxd
 ```{note}
 If `newuidmap/newgidmap` tools are present on your system and `/etc/subuid`, `etc/subgid` exist, they must be configured to allow the root user a contiguous range of at least 10M UID/GID.
 ```
+
+(installing-manage-access)=
+## Manage access to LXD
+
+Access control for LXD is based on group membership.
+The root user and all members of the `lxd` group can interact with the local daemon.
+See {ref}`security-daemon-access` for more information.
+
+If the `lxd` group is missing on your system, create it and restart the LXD daemon.
+You can then add trusted users to the group.
+Anyone added to this group will have full control over LXD.
+
+Because group membership is normally only applied at login, you might need to either re-open your user session or use the `newgrp lxd` command in the shell you're using to talk to LXD.
+
+````{important}
+% Include content from [../README.md](../README.md)
+```{include} ../README.md
+    :start-after: <!-- Include start security note -->
+    :end-before: <!-- Include end security note -->
+```
+````
 
 (installing-upgrade)=
 ## Upgrade LXD


### PR DESCRIPTION
Move the installation instructions from
https://linuxcontainers.org/lxd/getting-started-cli/ into the docs.