### PR TITLE
lxd/instance/qemu: Fix vsock id type

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7434,14 +7434,7 @@ func (d *qemu) vsockID() int {
 	// unique, non-clashing context ID for our guest.
 
 	info := DriverStatuses()[instancetype.VM].Info
-	feature, found := info.Features["vhost_vsock"]
-
-	vsockID, ok := feature.(int)
-	if !found || !ok {
-		vsockID = vsock.Host
-	}
-
-	return vsockID + 1 + d.id
+	return info.Features["vhost_vsock"].(int) + 1 + d.id
 }
 
 // InitPID returns the instance's current process ID.
@@ -7999,7 +7992,7 @@ func (d *qemu) checkFeatures(hostArch int, qemuPath string) (map[string]any, err
 		// Fallback to the default ID for a host system
 		features["vhost_vsock"] = vsock.Host
 	} else {
-		features["vhost_vsock"] = vsockID
+		features["vhost_vsock"] = int(vsockID)
 	}
 
 	return features, nil


### PR DESCRIPTION
Fixes regression introduced by https://github.com/lxc/lxd/pull/11834