### PR TITLE
github: move dependency review (~0s) to Code tests job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v3
+        if: github.event_name == 'pull_request'
+
       - name: Install Go
         uses: actions/setup-go@v4
         with:
@@ -253,17 +257,6 @@ jobs:
         env:
           CGO_ENABLED: 0
         run: go test -v ./shared/...
-
-  dependencies:
-    name: Vulnerable dependencies
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-
-      - name: Dependency Review
-        uses: actions/dependency-review-action@v3
 
   documentation:
     name: Documentation tests


### PR DESCRIPTION
The actual dependency review action takes ~0s but due to the extra checkout and cleanup, it ends up taking ~7s which == 1m of CI.