### PR TITLE
api: Restructure target checks for the instancesPost endpoint

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3288,13 +3288,11 @@ func evacuateInstances(ctx context.Context, opts evacuateOpts) error {
 
 		targetMemberInfo, err := evacuateClusterSelectTarget(ctx, opts.s, opts.gateway, inst, candidateMembers)
 		if err != nil {
-			return err
-		}
-
-		// Skip migration if no target available.
-		if targetMemberInfo == nil {
-			l.Warn("No migration target available for instance")
-			continue
+			if api.StatusErrorCheck(err, http.StatusNotFound) {
+				// Skip migration if no target is available
+				l.Warn("No migration target available for instance")
+				continue
+			}
 		}
 
 		// Start migrating the instance.

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -1139,6 +1139,10 @@ func (c *ClusterTx) GetNodeWithLeastInstances(ctx context.Context, members []Nod
 		}
 	}
 
+	if member == nil {
+		return nil, api.StatusErrorf(http.StatusNotFound, "No suitable cluster member could be found")
+	}
+
 	return member, nil
 }
 

--- a/shared/util.go
+++ b/shared/util.go
@@ -1371,3 +1371,15 @@ func JoinTokenDecode(input string) (*api.ClusterMemberJoinToken, error) {
 
 	return &j, nil
 }
+
+// TargetDetect returns either target node or group based on the provided prefix:
+// An invocation with `target=h1` returns "h1", "" and `target=@g1` returns "", "g1".
+func TargetDetect(target string) (targetNode string, targetGroup string) {
+	if strings.HasPrefix(target, "@") {
+		targetGroup = strings.TrimPrefix(target, "@")
+	} else {
+		targetNode = target
+	}
+
+	return
+}


### PR DESCRIPTION
Predecessor of https://github.com/lxc/lxd/pull/11813 to establish the new structure for cluster target permission checks.