### PR TITLE
doc: exclude pages from search index

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -168,7 +168,7 @@ source_suffix = ".md"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['html', 'README.md', '.sphinx']
+exclude_patterns = ['html', 'README.md', '.sphinx', 'config_options_cheat_sheet.md']
 
 # Open Graph configuration
 

--- a/doc/config_options_cheat_sheet.md
+++ b/doc/config_options_cheat_sheet.md
@@ -1,8 +1,14 @@
 ---
 orphan: true
+nosearch: true
 ---
 
 # Configuration options
+
+```{important}
+This page shows how to output configuration option documentation.
+The content in this page is for demonstration purposes only.
+```
 
 Some instance options:
 

--- a/doc/doc-cheat-sheet.md
+++ b/doc/doc-cheat-sheet.md
@@ -1,5 +1,6 @@
 ---
 orphan: true
+nosearch: true
 myst:
   substitutions:
     reuse_key: "This is **included** text."


### PR DESCRIPTION
Exclude the two cheat sheets from the search index. Since this only excludes the pages, but not the _objects_ in the page, also exclude the config options cheat sheet from processing.