### PR TITLE
lxd: Fix deviceEventListener resource scheduling when joining cluster

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1446,7 +1446,7 @@ func (d *Daemon) init() error {
 
 	if !d.os.MockMode {
 		// Start the scheduler
-		go deviceEventListener(d.State())
+		go deviceEventListener(d.State)
 
 		prefixPath := os.Getenv("LXD_DEVMONITOR_DIR")
 		if prefixPath == "" {


### PR DESCRIPTION
Pass  `deviceEventListener` a function that can get a fresh copy of state, rather than using a long held version, which can become out of date.

This manifested itself in no container CPU scheduling being run for instances launched on a server that had just joined a cluster.

This was because the `ServerName` property in the `state.State` object `deviceEventListener` was passed on LXD start up contained "none" but after the server had joined the cluster its ServerName changed to its cluster member name.

This then meant that the `instance.LoadNodeAll()` call used inside `deviceEventListener` was filtering instances that were on server "none", of which there weren't any because the new instances were associated with the cluster member's name.

This then meant that those instances did not get their CPU scheduling configured until LXD was next reloaded.