### PR TITLE
lxd/instance/drivers: Ensure root disk device

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4206,6 +4206,11 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		if oldErr == nil && newErr == nil && oldRootDev["pool"] != newRootDev["pool"] {
 			return fmt.Errorf("Cannot update root disk device pool name to %q", newRootDev["pool"])
 		}
+
+		// Ensure the instance has a root disk.
+		if newErr != nil {
+			return fmt.Errorf("Invalid root disk device: %w", newErr)
+		}
 	}
 
 	// Run through initLXC to catch anything we missed

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5078,6 +5078,11 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		if oldErr == nil && newErr == nil && oldRootDev["pool"] != newRootDev["pool"] {
 			return fmt.Errorf("Cannot update root disk device pool name to %q", newRootDev["pool"])
 		}
+
+		// Ensure the instance has a root disk.
+		if newErr != nil {
+			return fmt.Errorf("Invalid root disk device: %w", newErr)
+		}
 	}
 
 	// If apparmor changed, re-validate the apparmor profile (even if not running).

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -647,4 +647,11 @@ test_basic_usage() {
   lxc init testimage c1
   lxc rebuild c1 --empty
   lxc delete c1 -f
+
+  # Test assigning an empty profile (with no root disk device) to an instance.
+  lxc init testimage c1
+  lxc profile create foo
+  ! lxc profile assign c1 foo || false
+  lxc profile delete foo
+  lxc delete -f c1
 }


### PR DESCRIPTION
When updating an instance, it's possible to override the devices
in such a way that it lacks a root disk device.

This adds a root device check before finalizing the update so that an
instance will always have a root disk device.

Fixes #11900

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
