### PR TITLE
Changed the text from main to master because the actual branch is master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Changes to this project should be proposed as pull requests on GitHub
 at: [`https://github.com/lxc/lxd`](https://github.com/lxc/lxd)
 
 Proposed changes will then go through code review there and once approved,
-be merged in the main branch.
+be merged in the master branch.
 
 ## Commit structure
 


### PR DESCRIPTION
Hey there,

I noticed a small typo in the [CONTRIBUTING.md](https://github.com/lxc/lxd/blob/master/CONTRIBUTING.md#pull-requests) file in which the main branch was written, but there is no main branch. Instead, there is a master branch that should be written. So I updated that typo.

Thank you!