### PR TITLE
Added a heading in the client/operations.go file that was missing

### DIFF
--- a/client/operations.go
+++ b/client/operations.go
@@ -144,6 +144,9 @@ func (op *operation) WaitContext(ctx context.Context) error {
 	return nil
 }
 
+// setupListener initiates an event listener for an operation and manages updates to the operation's state.
+// It adds handlers to process events, monitors the listener for completion or errors,
+// and triggers a manual refresh of the operation's state to prevent race conditions.
 func (op *operation) setupListener() error {
 	// Make sure we're not racing with ourselves
 	op.handlerLock.Lock()


### PR DESCRIPTION
Hey there,

There was documentation missing in one [function](https://github.com/lxc/lxd/blob/71fd927db5672c33fa2c8a7b04ccb555834dba53/client/operations.go#L147) in the **client/operations.go** file. I added 2 lines of text there to make them understandable.

Thank you!