### PR TITLE
oidc: Don't fail if server is not reachable

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -978,12 +978,7 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		if oidcIssuer == "" || oidcClientID == "" {
 			d.oidcVerifier = nil
 		} else {
-			var err error
-
-			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience)
-			if err != nil {
-				return fmt.Errorf("Failed setting up OpenID Connect: %w", err)
-			}
+			d.oidcVerifier = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience)
 		}
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1339,10 +1339,7 @@ func (d *Daemon) init() error {
 
 	// Setup OIDC authentication.
 	if oidcIssuer != "" && oidcClientID != "" {
-		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience)
-		if err != nil {
-			return err
-		}
+		d.oidcVerifier = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience)
 	}
 
 	// Setup BGP listener.


### PR DESCRIPTION
This fixes an issue where LXD would fail on start if the OIDC server
isn't reachable.

Instead of failing on start, `NewVerifier` always returns a Verifier
struct, regardless of whether the OIDC server is reachable or not. If
unreachable, the verifier will try contacting the OIDC server during
the actual authentication. If that fails, so does the authentication.

This also removes the `keySet` variable from the `Verifier` struct as
it's not used anywhere.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
