### PR TITLE
Fix LXD lowering host bridge MTU

### DIFF
--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -223,24 +223,45 @@ func networkCreateVethPair(hostName string, m deviceConfig.Device) (string, uint
 		},
 	}
 
-	// Set the MTU on both ends. If not specified and has parent, will inherit MTU from parent.
+	// Set the MTU on both ends.
+	// The host side should always line up with the bridge to avoid accidentally lowering the bridge MTU.
+	// The instance side should use the configured MTU (if any), if not, it should match the host side.
+	var instanceMTU uint32
+	var parentMTU uint32
+
+	if m["parent"] != "" {
+		mtu, err := network.GetDevMTU(m["parent"])
+		if err != nil {
+			return "", 0, fmt.Errorf("Failed to get the parent MTU: %w", err)
+		}
+
+		parentMTU = uint32(mtu)
+	}
+
 	if m["mtu"] != "" {
 		mtu, err := strconv.ParseUint(m["mtu"], 10, 32)
 		if err != nil {
 			return "", 0, fmt.Errorf("Invalid MTU specified: %w", err)
 		}
 
-		veth.MTU = uint32(mtu)
-	} else if m["parent"] != "" {
-		mtu, err := network.GetDevMTU(m["parent"])
-		if err != nil {
-			return "", 0, fmt.Errorf("Failed to get the parent MTU: %w", err)
-		}
-
-		veth.MTU = mtu
+		instanceMTU = uint32(mtu)
 	}
 
-	veth.Peer.MTU = veth.MTU
+	if instanceMTU == 0 && parentMTU > 0 {
+		instanceMTU = parentMTU
+	}
+
+	if parentMTU == 0 && instanceMTU > 0 {
+		parentMTU = instanceMTU
+	}
+
+	if instanceMTU > 0 {
+		veth.Peer.MTU = instanceMTU
+	}
+
+	if parentMTU > 0 {
+		veth.MTU = parentMTU
+	}
 
 	// Set the MAC address on peer.
 	if m["hwaddr"] != "" {
@@ -276,7 +297,7 @@ func networkCreateVethPair(hostName string, m deviceConfig.Device) (string, uint
 		return "", 0, fmt.Errorf("Failed to create the veth interfaces %q and %q: %w", hostName, veth.Peer.Name, err)
 	}
 
-	return veth.Peer.Name, veth.MTU, nil
+	return veth.Peer.Name, veth.Peer.MTU, nil
 }
 
 // networkCreateTap creates and configures a TAP device.

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -89,8 +89,8 @@ test_container_devices_nic_bridged() {
     false
   fi
 
-  # Check profile custom MTU is applied on host side of veth.
-  if ! grep "1400" /sys/class/net/"${vethHostName}"/mtu ; then
+  # Check profile custom MTU doesn't affect the host.
+  if ! grep "1500" /sys/class/net/"${vethHostName}"/mtu ; then
     echo "host veth mtu invalid"
     false
   fi
@@ -170,8 +170,8 @@ test_container_devices_nic_bridged() {
     false
   fi
 
-  # Check custom MTU is applied host-side on hot-plug.
-  if !  grep "1401" /sys/class/net/"${vethHostName}"/mtu ; then
+  # Check custom MTU doesn't affect the host.
+  if ! grep "1500" /sys/class/net/"${vethHostName}"/mtu ; then
     echo "host veth mtu invalid"
     false
   fi
@@ -221,8 +221,8 @@ test_container_devices_nic_bridged() {
     false
   fi
 
-  # Checl profile custom MTU is applied host-side on hot-removal.
-  if ! grep "1400" /sys/class/net/"${vethHostName}"/mtu ; then
+  # Check custom MTU doesn't affect the host.
+  if ! grep "1500" /sys/class/net/"${vethHostName}"/mtu ; then
     echo "host veth mtu invalid"
     false
   fi


### PR DESCRIPTION
When dealing with reasonably complex bridges that are not LXD managed, in my case, a bridge using VLAN filtering, it's not unusual for some VLANs to use a different MTU than others.

The problem is that currently LXD slams the same MTU on both the host and guest side device.
This feels like a good idea overall, if it wasn't for the fact that the Linux kernel will automatically lower the bridge MTU should any device be added to it with an MTU lower than its current value.

In practice what this means is that starting a single instance which has a network interface using an MTU lower than the current one on the bridge (1500 vs 9000 in my case) will cause the bridge MTU to get lowered and break a whole bunch of stuff.

Instead what we need to do is ensure that the host side device always has the same MTU as the bridge it's being put into, then set the user request MTU on the guest side device instead.


This all does cause a small behavior difference though, as MTU stands for maximum "transmission" unit, the kernel only enforces it on egress, not on ingress. So while with the current (buggy) implementation, this effectively ensures that a container with mtu=1500 will never receive a packet > 1500, the fixed logic technically doesn't prevent it.
A host with a bridge MTU of 9000 and a container with an interface MTU of 1500 will now be able to receive packets headed to it with a MTU of up to 9000, but it won't be able to send any response or any new packet out with an MTU higher than its configured 1500.

This certainly isn't ideal but the current behavior is also a grey area as we have a bridge that can be forced back to its full MTU of 9000 while retaining some devices inside of it with an MTU of 1500. This most likely results in packets being dropped somewhere in the kernel, rather than the physical version of this setup where they would just get truncated to match the MTU.